### PR TITLE
Fix LLVM internal assertion for host-device JIT

### DIFF
--- a/lib/JitEngineHost.cpp
+++ b/lib/JitEngineHost.cpp
@@ -221,8 +221,11 @@ JitEngineHost::specializeIR(StringRef FnName, StringRef Suffix, StringRef IR,
           continue;
 
       auto ExecutorAddr = LLJITPtr->lookup(GV.getName());
-      if (ExecutorAddr)
+      auto Error = ExecutorAddr.takeError();
+      if (!Error)
         continue;
+      // Consume the error and fix with static linking.
+      consumeError(std::move(Error));
 
       DBG(dbgs() << "Resolve statically missing GV symbol " << GV.getName()
                  << "\n");


### PR DESCRIPTION
- LLVM built with assertions on will abort if the error of the Expected value is not handled.