### PR TITLE
Create add_proteus cmake function for importing

### DIFF
--- a/cmake/proteusConfig.cmake.in
+++ b/cmake/proteusConfig.cmake.in
@@ -4,3 +4,14 @@ find_package(LLVM REQUIRED CONFIG)
 
 include("${CMAKE_CURRENT_LIST_DIR}/proteusTargets.cmake")
 check_required_components("@PROJECT_NAME@")
+
+function(add_proteus target)
+    target_compile_options(${target} PUBLIC
+        "-fpass-plugin=\$<TARGET_FILE:ProteusPass>"
+    )
+
+    target_link_options(${target} PUBLIC
+        "SHELL:\$<\$<LINK_LANGUAGE:HIP>:-Xoffload-linker --load-pass-plugin=\$<TARGET_FILE:ProteusPass>>")
+
+    target_link_libraries(${target} PUBLIC proteus)
+endfunction()


### PR DESCRIPTION
Support easily integrating proteus in a cmake project using the `add_proteus` function. Avoids linking errors when included ProteusPass as a linked library (thanks @tbennun)