### PR TITLE
Register proteus pass late

### DIFF
--- a/pass/ProteusPass.cpp
+++ b/pass/ProteusPass.cpp
@@ -1154,11 +1154,11 @@ llvm::PassPluginLibraryInfo getProteusJitPassPluginInfo() {
 
     // PB.registerPipelineStartEPCallback(
     // PB.registerOptimizerLastEPCallback(
-    PB.registerPipelineEarlySimplificationEPCallback(
-        [&](ModulePassManager &MPM, auto) {
-          MPM.addPass(ProteusJitPass{false});
-          return true;
-        });
+    // PB.registerPipelineEarlySimplificationEPCallback(
+    PB.registerOptimizerLastEPCallback([&](ModulePassManager &MPM, auto) {
+      MPM.addPass(ProteusJitPass{false});
+      return true;
+    });
 
     PB.registerFullLinkTimeOptimizationEarlyEPCallback(
         [&](ModulePassManager &MPM, auto) {


### PR DESCRIPTION
Registers pass late as discussed in #79 . 

Pending tasks:
- [x] Verify correctness in systems and architectures
- [ ] Verify constant threadDim/BlockDim specialization ( PR #42 ) 