### PR TITLE
Sanitize cmake files for tests

### DIFF
--- a/tests/cpu/CMakeLists.txt
+++ b/tests/cpu/CMakeLists.txt
@@ -2,7 +2,7 @@ function(CREATE_CPU_TEST exe check_source)
     add_executable(${exe} ${check_source} ${ARGN})
 
     set_source_files_properties(${check_source} PROPERTIES
-        OBJECT_DEPENDS ${CMAKE_SOURCE_DIR}/pass/ProteusPass.cpp
+        OBJECT_DEPENDS ${PROJECT_SOURCE_DIR}/pass/ProteusPass.cpp
     )
     add_dependencies(${exe} ProteusPass)
 

--- a/tests/gpu/CMakeLists.txt
+++ b/tests/gpu/CMakeLists.txt
@@ -11,11 +11,11 @@ function(CREATE_GPU_TEST exe check_source)
     add_executable(${exe}.${lang} ${check_source} ${ARGN})
     set_source_files_properties(${check_source} ${ARGN} PROPERTIES
         LANGUAGE ${lang}
-        OBJECT_DEPENDS ${CMAKE_SOURCE_DIR}/pass/ProteusPass.cpp
+        OBJECT_DEPENDS ${PROJECT_SOURCE_DIR}/pass/ProteusPass.cpp
     )
     add_dependencies(${exe}.${lang} ProteusPass)
 
-    target_link_libraries(${exe}.${lang} PUBLIC ProteusPass proteus)
+    target_link_libraries(${exe}.${lang} PUBLIC proteus)
 
     target_compile_options(
         ${exe}.${lang}
@@ -41,10 +41,10 @@ function(CREATE_GPU_TEST_RDC exe check_source)
     add_executable(${exe}.${lang}.rdc ${check_source} ${ARGN})
     set_source_files_properties(${check_source} ${ARGN} PROPERTIES
         LANGUAGE ${lang}
-        OBJECT_DEPENDS ${CMAKE_SOURCE_DIR}/pass/ProteusPass.cpp
+        OBJECT_DEPENDS ${PROJECT_SOURCE_DIR}/pass/ProteusPass.cpp
     )
 
-    target_link_libraries(${exe}.${lang}.rdc PUBLIC ProteusPass proteus)
+    target_link_libraries(${exe}.${lang}.rdc PUBLIC proteus)
 
     if(ENABLE_HIP)
         # This is unsupported see: https://gitlab.kitware.com/cmake/cmake/-/issues/23210
@@ -55,6 +55,7 @@ function(CREATE_GPU_TEST_RDC exe check_source)
             ${exe}.${lang}.rdc
             PUBLIC
             -fgpu-rdc
+            -fpass-plugin=$<TARGET_FILE:ProteusPass>
         )
 
         target_link_options(${exe}.${lang}.rdc PUBLIC -fgpu-rdc --hip-link)

--- a/tests/gpu/CMakeLists.txt
+++ b/tests/gpu/CMakeLists.txt
@@ -58,7 +58,13 @@ function(CREATE_GPU_TEST_RDC exe check_source)
             -fpass-plugin=$<TARGET_FILE:ProteusPass>
         )
 
-        target_link_options(${exe}.${lang}.rdc PUBLIC -fgpu-rdc --hip-link)
+        target_link_options(
+            ${exe}.${lang}.rdc
+            PUBLIC
+            -fgpu-rdc
+            --hip-link
+            -Xoffload-linker --load-pass-plugin=$<TARGET_FILE:ProteusPass>
+        )
     elseif(ENABLE_CUDA)
         target_compile_options(
             ${exe}.${lang}.rdc


### PR DESCRIPTION
- Replace CMAKE_SOURCE_DIR in OBJECT_DEPENDS with PROJECT_SOURCE_DIR for git submodule deployment
- Remove linkings with ProteusPass

Closes #71 