### PR TITLE
Fix CMake config linking external projects with incorrect LLVM/LLD

### DIFF
--- a/cmake/proteusConfig.cmake.in
+++ b/cmake/proteusConfig.cmake.in
@@ -1,6 +1,7 @@
 @PACKAGE_INIT@
 
 find_package(LLVM REQUIRED CONFIG)
+find_package(LLD REQUIRED)
 
 include("${CMAKE_CURRENT_LIST_DIR}/proteusTargets.cmake")
 check_required_components("@PROJECT_NAME@")

--- a/cmake/proteusConfig.cmake.in
+++ b/cmake/proteusConfig.cmake.in
@@ -1,6 +1,12 @@
 @PACKAGE_INIT@
 
+set(PROTEUS_LLVM_DIR @LLVM_DIR@)
 find_package(LLVM REQUIRED CONFIG)
+if (NOT "${LLVM_DIR}" STREQUAL "${PROTEUS_LLVM_DIR}")
+    message(FATAL_ERROR "Mismatch between target LLVM_DIR = ${LLVM_DIR} "
+    "and Proteus LLVM_DIR = ${PROTEUS_LLVM_DIR}. "
+    "Use the same LLVM installation when compiling.")
+endif()
 find_package(LLD REQUIRED)
 
 include("${CMAKE_CURRENT_LIST_DIR}/proteusTargets.cmake")

--- a/cmake/proteusConfig.cmake.in
+++ b/cmake/proteusConfig.cmake.in
@@ -1,13 +1,22 @@
 @PACKAGE_INIT@
 
-set(PROTEUS_LLVM_DIR @LLVM_DIR@)
-find_package(LLVM REQUIRED CONFIG)
+set(PROTEUS_LLVM_DIR "@LLVM_DIR@")
+set(PROTEUS_LLD_DIR "@LLD_DIR@")
+find_dependency(LLVM REQUIRED CONFIG)
+
 if (NOT "${LLVM_DIR}" STREQUAL "${PROTEUS_LLVM_DIR}")
     message(FATAL_ERROR "Mismatch between target LLVM_DIR = ${LLVM_DIR} "
     "and Proteus LLVM_DIR = ${PROTEUS_LLVM_DIR}. "
     "Use the same LLVM installation when compiling.")
 endif()
-find_package(LLD REQUIRED)
+message(STATUS "LLVM DIR = ${LLVM_DIR}")
+
+get_property(enabled_languages GLOBAL PROPERTY ENABLED_LANGUAGES)
+message(STATUS "Enabled languages: ${enabled_languages}")
+if("HIP" IN_LIST enabled_languages)
+    find_dependency(LLD NO_DEFAULT_PATH PATHS ${PROTEUS_LLD_DIR} REQUIRED)
+    message(STATUS "LLD DIR = ${LLD_DIR}")
+endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/proteusTargets.cmake")
 check_required_components("@PROJECT_NAME@")


### PR DESCRIPTION
Before this PR, systems with built-in lld would link to the incorrect version, leading to incompatibilities during runtime.