### PR TITLE
Fix alternative HIP codegen

### DIFF
--- a/src/lib/JitEngineDeviceHIP.cpp
+++ b/src/lib/JitEngineDeviceHIP.cpp
@@ -329,8 +329,9 @@ JitEngineDeviceHIP::codegenObject(Module &M, StringRef DeviceArch) {
                                             SharedObjectPath))
       FATAL_ERROR(EC.message());
 
-    std::vector<const char *> Args{"ld.lld", "-shared", ObjectPath.c_str(),
-                                   "-o", SharedObjectPath.c_str()};
+    std::vector<const char *> Args{"ld.lld",  "--no-undefined",
+                                   "-shared", ObjectPath.c_str(),
+                                   "-o",      SharedObjectPath.c_str()};
 
     lld::Result S = lld::lldMain(Args, llvm::outs(), llvm::errs(),
                                  {{lld::Gnu, &lld::elf::link}});
@@ -338,8 +339,8 @@ JitEngineDeviceHIP::codegenObject(Module &M, StringRef DeviceArch) {
       FATAL_ERROR("Error: lld failed");
   }
 
-  ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> Buffer =
-      llvm::MemoryBuffer::getFile(SharedObjectPath);
+  ErrorOr<std::unique_ptr<MemoryBuffer>> Buffer =
+      MemoryBuffer::getFileAsStream(SharedObjectPath);
   if (!Buffer)
     FATAL_ERROR("Error reading file: " + Buffer.getError().message());
 

--- a/tests/cpu/CMakeLists.txt
+++ b/tests/cpu/CMakeLists.txt
@@ -26,9 +26,11 @@ endfunction()
 
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/lit.cfg.py "
 import lit.formats
+import os
 
 config.name = 'LIT tests'
 config.test_format = lit.formats.ShTest(True)
+config.environment = os.environ.copy()
 
 config.suffixes = ['.cpp']
 config.test_source_root = '${CMAKE_CURRENT_SOURCE_DIR}'

--- a/tests/gpu/CMakeLists.txt
+++ b/tests/gpu/CMakeLists.txt
@@ -199,9 +199,11 @@ endif()
 
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/lit.cfg.py "
 import lit.formats
+import os
 
 config.name = 'LIT tests'
 config.test_format = lit.formats.ShTest(True)
+config.environment = os.environ.copy()
 
 config.suffixes = ['.cpp']
 config.test_source_root = '${CMAKE_CURRENT_SOURCE_DIR}'


### PR DESCRIPTION
- Fix object buffer bug, deleting backing temp file
- Add no-undefined to lld to detect linking errors
- Fix testing to forward env vars through lit