### PR TITLE
Fix type matching for lambdas with arguments 

### DIFF
--- a/src/pass/ProteusPass.cpp
+++ b/src/pass/ProteusPass.cpp
@@ -223,7 +223,7 @@ private:
   bool isLambdaFunction(const Function &F) {
     std::string DemangledName = demangle(F.getName().str());
     return StringRef{DemangledName}.contains("'lambda") &&
-           StringRef{DemangledName}.contains("'()::operator()");
+           StringRef{DemangledName}.contains(")::operator()");
   }
 
   std::string getJitBitcodeUniqueName(Module &M) {
@@ -261,8 +261,9 @@ private:
         if (!isDeviceKernel(Fn) && !isLambdaFunction(*Fn))
           FATAL_ERROR(std::string{} + __FILE__ + ":" +
                       std::to_string(__LINE__) +
-                      " => Expected the annotated Fn " + Fn->getName() +
-                      " to be a kernel function or device lambda function!");
+                      " => Expected the annotated Fn " + Fn->getName() + " (" +
+                      demangle(Fn->getName().str()) +
+                      ") to be a kernel function or device lambda function!");
 
         continue;
       }

--- a/tests/gpu/lambda.cpp
+++ b/tests/gpu/lambda.cpp
@@ -62,7 +62,7 @@ int main(int argc, char **argv) {
   std::cout << "x[0] = " << x[0] << "\n";
 
   register_run(
-      2, [ =, c = proteus::jit_variable(a) ] __device__
+      2, [ =, c = proteus::jit_variable(c) ] __device__
       __attribute__((annotate("jit"))) (int i) { x[i] = c; });
 
   std::cout << "x[0:1] = " << x[0] << "," << x[1] << "\n";
@@ -77,9 +77,10 @@ int main(int argc, char **argv) {
 }
 
 // CHECK: x[0] = 3.14
+// CHECK: x[0:1] = 4.56,4.56
 // CHECK: x[0] = 4.37
 // CHECK: x[0] = 6.56
-// CHECK: JitCache hits 0 total 3
+// CHECK: JitCache hits 0 total 4
 // CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-// CHECK-FIRST: JitStorageCache hits 0 total 3
-// CHECK-SECOND: JitStorageCache hits 3 total 3
+// CHECK-FIRST: JitStorageCache hits 0 total 4
+// CHECK-SECOND: JitStorageCache hits 4 total 4


### PR DESCRIPTION
Loosen demangled name matching strictness to handle lambda launchers with arguments and print demangled name if check fails. Previously I'd get errors for something like the following for `... void kernel(int n, T LB)`:

`
fatal error: error in backend: .../proteus/src/pass/ProteusPass.cpp:266 => .../proteus/src/pass/ProteusPass.cpp:263 => Expected the annotated Fn _ZZ4mainENKUliE_clEi (main::'lambda'(int)::operator()(int) const) to be a kernel function or device lambda function!
`

I also added an example to the gpu lambda test.