### PR TITLE
feature: change CMake so add_proteus is callable from a project using proteus as a submodule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ if(PROTEUS_ENABLE_DEBUG)
 endif()
 
 include(cmake/SetupLLVM.cmake)
+include(cmake/ProteusFunctions.cmake)
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
@@ -62,5 +63,6 @@ install(EXPORT proteusTargets
 install(FILES
   "${PROJECT_BINARY_DIR}/proteusConfigVersion.cmake"
   "${PROJECT_BINARY_DIR}/proteusConfig.cmake"
+  "${PROJECT_SOURCE_DIR}/cmake/ProteusFunctions.cmake"
   DESTINATION
   ${CMAKE_INSTALL_LIBDIR}/cmake/proteus)

--- a/cmake/ProteusFunctions.cmake
+++ b/cmake/ProteusFunctions.cmake
@@ -1,0 +1,28 @@
+function(add_proteus target)
+    target_compile_options(${target} PRIVATE
+        "-fpass-plugin=\$<TARGET_FILE:ProteusPass>"
+    )
+
+    target_link_options(${target} PRIVATE
+        "SHELL:\$<\$<LINK_LANGUAGE:HIP>:-Xoffload-linker --load-pass-plugin=\$<TARGET_FILE:ProteusPass>>")
+
+    get_target_property(target_type ${target} TYPE)
+    if(NOT target_type)
+        message(FATAL_ERROR "Target ${target} not found or does not have a TYPE property!")
+    endif()
+
+    get_target_property(proteus_target_type proteus TYPE)
+    if(NOT proteus_target_type)
+        message(FATAL_ERROR "Target proteus not found or does not have a TYPE property!")
+    endif()
+
+    # Do not link libproteus if it is a static library and the target is a
+    # shared library, to avoid duplicating LLVM linking that causes static
+    # initialization errors. Instead propagate the dependency of static
+    # libproteus and its LLVM dependencies using INTERFACE.
+    if(target_type STREQUAL "SHARED_LIBRARY" AND proteus_target_type STREQUAL "STATIC_LIBRARY")
+        target_link_libraries(${target} INTERFACE -Wl,--allow-shlib-undefined proteus)
+    else()
+        target_link_libraries(${target} PRIVATE proteus)
+    endif()
+endfunction()

--- a/cmake/proteusConfig.cmake.in
+++ b/cmake/proteusConfig.cmake.in
@@ -1,7 +1,6 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-include(ProteusFunctions.cmake)
 set(PROTEUS_LLVM_DIR "@LLVM_DIR@")
 find_dependency(LLVM REQUIRED CONFIG)
 
@@ -12,5 +11,6 @@ if (NOT "${LLVM_DIR}" STREQUAL "${PROTEUS_LLVM_DIR}")
 endif()
 message(STATUS "LLVM DIR = ${LLVM_DIR}")
 
+include("${CMAKE_CURRENT_LIST_DIR}/ProteusFunctions.cmake")
 include("${CMAKE_CURRENT_LIST_DIR}/proteusTargets.cmake")
 check_required_components("@PROJECT_NAME@")

--- a/cmake/proteusConfig.cmake.in
+++ b/cmake/proteusConfig.cmake.in
@@ -1,6 +1,7 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
+include(ProteusFunctions.cmake)
 set(PROTEUS_LLVM_DIR "@LLVM_DIR@")
 find_dependency(LLVM REQUIRED CONFIG)
 
@@ -13,32 +14,3 @@ message(STATUS "LLVM DIR = ${LLVM_DIR}")
 
 include("${CMAKE_CURRENT_LIST_DIR}/proteusTargets.cmake")
 check_required_components("@PROJECT_NAME@")
-
-function(add_proteus target)
-    target_compile_options(${target} PRIVATE
-        "-fpass-plugin=\$<TARGET_FILE:ProteusPass>"
-    )
-
-    target_link_options(${target} PRIVATE
-        "SHELL:\$<\$<LINK_LANGUAGE:HIP>:-Xoffload-linker --load-pass-plugin=\$<TARGET_FILE:ProteusPass>>")
-
-    get_target_property(target_type ${target} TYPE)
-    if(NOT target_type)
-        message(FATAL_ERROR "Target ${target} not found or does not have a TYPE property!")
-    endif()
-
-    get_target_property(proteus_target_type proteus TYPE)
-    if(NOT proteus_target_type)
-        message(FATAL_ERROR "Target proteus not found or does not have a TYPE property!")
-    endif()
-
-    # Do not link libproteus if it is a static library and the target is a
-    # shared library, to avoid duplicating LLVM linking that causes static
-    # initialization errors. Instead propagate the dependency of static
-    # libproteus and its LLVM dependencies using INTERFACE.
-    if(target_type STREQUAL "SHARED_LIBRARY" AND proteus_target_type STREQUAL "STATIC_LIBRARY")
-        target_link_libraries(${target} INTERFACE -Wl,--allow-shlib-undefined proteus)
-    else()
-        target_link_libraries(${target} PRIVATE proteus)
-    endif()
-endfunction()


### PR DESCRIPTION
note: I still want to add an integration test of this