### PR TITLE
Simplify testing for speed

### DIFF
--- a/scripts/gitlab/ci-build-test.sh
+++ b/scripts/gitlab/ci-build-test.sh
@@ -61,10 +61,8 @@ if grep -q "Manually-specified variables were not used by the project:" cmake_ou
 fi
 make -j
 
-if  [ "$PROTEUS_CI_ENABLE_DEBUG" == "on" ] || \
-    [ "$PROTEUS_CI_BUILD_SHARED" == "on" ] || \
-    [ "$PROTEUS_CI_ENABLE_TRACING" == "on" ]; then
-  echo "Skipping tests for debug, or shared lib, or time tracing builds."
+if  [ "$PROTEUS_CI_ENABLE_DEBUG" == "on" ] || [ "$PROTEUS_CI_ENABLE_TIME_TRACING" == "on" ]; then
+  echo "Skipping tests for debug output or time tracing builds."
   exit 0
 fi
 

--- a/scripts/gitlab/ci-build-test.sh
+++ b/scripts/gitlab/ci-build-test.sh
@@ -60,6 +60,14 @@ if grep -q "Manually-specified variables were not used by the project:" cmake_ou
     exit 1
 fi
 make -j
+
+if  [ "$PROTEUS_CI_ENABLE_DEBUG" == "on" ] || \
+    [ "$PROTEUS_CI_BUILD_SHARED" == "on" ] || \
+    [ "$PROTEUS_CI_ENABLE_TRACING" == "on" ]; then
+  echo "Skipping tests for debug, or shared lib, or time tracing builds."
+  exit 0
+fi
+
 # Test synchronous compilation by default.
 echo "### TESTING SYNC COMPILATION ###"
 ctest -T test --output-on-failure


### PR DESCRIPTION
- Run build tests for all configurations as before
- Run ctests only for the "production" configurations (no debug output, no time tracing)