### PR TITLE
[NFC] Update testing for checking specialization traces

### DIFF
--- a/docs/user/config.md
+++ b/docs/user/config.md
@@ -3,18 +3,19 @@
 Proteus exposes a number of possible runtime configuration options, accessible
 through environment variables.
 
-| Environment Variable               | Possible Values                                                                | Description                                                               |
-| ---------------------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------- |
-| `PROTEUS_USE_STORED_CACHE`         | 0 or 1 (default: 1)                                                            | Enable the persistent storage cache                                       |
-| `PROTEUS_SPECIALIZE_LAUNCH_BOUNDS` | 0 or 1 (default: 1)                                                            | Set or not launch bouds on JIT kernels                                    |
-| `PROTEUS_SPECIALIZE_ARGS`          | 0 or 1 (default: 1)                                                            | Specialize JIT functions for input arguments                              |
-| `PROTEUS_SPECIALIZE_DIMS`          | 0 or 1 (default: 1)                                                            | Specialize JIT kernels for launch dimensions                              |
-| `PROTEUS_CODEGEN`                  | "rtc", "serial", "parallel", "thinlto" (default: "rtc")                        | Use HIP RTC, serial, parallel, or thinlto code generation                 |
-| `PROTEUS_DISABLE`                  | 0 or 1 (default: 0)                                                            | Disable Proteus (no JIT compilation)                                      |
-| `PROTEUS_DUMP_LLVM_IR`             | 0 or 1 (default: 0)                                                            | Dump the LLVM IR of JIT modules in the directory `.proteus-dump`          |
-| `PROTEUS_RELINK_GLOBALS_BY_COPY`   | 0 or 1 (default: 0)                                                            | Relink device global variables at kernel launch (instead of ELF patching) |
+| Environment Variable               | Possible Values                                                                     | Description                                                               |
+| ---------------------------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `PROTEUS_USE_STORED_CACHE`         | 0 or 1 (default: 1)                                                                 | Enable the persistent storage cache                                       |
+| `PROTEUS_SPECIALIZE_LAUNCH_BOUNDS` | 0 or 1 (default: 1)                                                                 | Set or not launch bouds on JIT kernels                                    |
+| `PROTEUS_SPECIALIZE_ARGS`          | 0 or 1 (default: 1)                                                                 | Specialize JIT functions for input arguments                              |
+| `PROTEUS_SPECIALIZE_DIMS`          | 0 or 1 (default: 1)                                                                 | Specialize JIT kernels for launch dimensions                              |
+| `PROTEUS_CODEGEN`                  | "rtc", "serial", "parallel", "thinlto" (default: "rtc")                             | Use HIP RTC, serial, parallel, or thinlto code generation                 |
+| `PROTEUS_DISABLE`                  | 0 or 1 (default: 0)                                                                 | Disable Proteus (no JIT compilation)                                      |
+| `PROTEUS_DUMP_LLVM_IR`             | 0 or 1 (default: 0)                                                                 | Dump the LLVM IR of JIT modules in the directory `.proteus-dump`          |
+| `PROTEUS_RELINK_GLOBALS_BY_COPY`   | 0 or 1 (default: 0)                                                                 | Relink device global variables at kernel launch (instead of ELF patching) |
 | `PROTEUS_KERNEL_CLONE`             | "link-clone-prune", "link-clone-light", "cross-clone" (default: "link-clone-light") | Cloning method for JIT module creation, default is generally the fastest  |
-| `PROTEUS_ASYNC_COMPILATION`        | 0 or 1 (default: 0)                                                            | Enable asynchronous compilation                                           |
-| `PROTEUS_ASYNC_COMPILATION`        | 0 or 1 (default: 0)                                                            | Enable asynchronous compilation                                           |
-| `PROTEUS_ASYNC_THREADS`            | >=1 (default: 1)                                                               | Set number of threads for asynchronous compilation                        |
-| `PROTEUS_ASYNC_TEST_BLOCKING`      | 0 or 1 (default: 0)                                                            | Make asynchronous compilation blocking for testing                        |
+| `PROTEUS_ASYNC_COMPILATION`        | 0 or 1 (default: 0)                                                                 | Enable asynchronous compilation                                           |
+| `PROTEUS_ASYNC_COMPILATION`        | 0 or 1 (default: 0)                                                                 | Enable asynchronous compilation                                           |
+| `PROTEUS_ASYNC_THREADS`            | >=1 (default: 1)                                                                    | Set number of threads for asynchronous compilation                        |
+| `PROTEUS_ASYNC_TEST_BLOCKING`      | 0 or 1 (default: 0)                                                                 | Make asynchronous compilation blocking for testing                        |
+| `PROTEUS_TRACE_OUTPUT`              | 0 or 1 (default: 0)                                                                 | Print trace output in stdout (shows information on Proteus specialization) |

--- a/include/proteus/CompilationTask.hpp
+++ b/include/proteus/CompilationTask.hpp
@@ -23,6 +23,7 @@ private:
   dim3 BlockDim;
   dim3 GridDim;
   SmallVector<int32_t> RCIndices;
+  ArrayRef<int32_t> RCTypes;
   SmallVector<RuntimeConstant> RCVec;
   SmallVector<std::pair<std::string, StringRef>> LambdaCalleeInfo;
   std::unordered_map<std::string, const void *> VarNameToDevPtr;
@@ -48,7 +49,7 @@ public:
   CompilationTask(
       MemoryBufferRef Bitcode, HashT HashValue, const std::string &KernelName,
       std::string &Suffix, dim3 BlockDim, dim3 GridDim,
-      const SmallVector<int32_t> &RCIndices,
+      const SmallVector<int32_t> &RCIndices, ArrayRef<int32_t> RCTypes,
       const SmallVector<RuntimeConstant> &RCVec,
       const SmallVector<std::pair<std::string, StringRef>> &LambdaCalleeInfo,
       const std::unordered_map<std::string, const void *> &VarNameToDevPtr,
@@ -58,8 +59,8 @@ public:
       bool SpecializeLaunchBounds)
       : Bitcode(Bitcode), HashValue(HashValue), KernelName(KernelName),
         Suffix(Suffix), BlockDim(BlockDim), GridDim(GridDim),
-        RCIndices(RCIndices), RCVec(RCVec), LambdaCalleeInfo(LambdaCalleeInfo),
-        VarNameToDevPtr(VarNameToDevPtr),
+        RCIndices(RCIndices), RCTypes(RCTypes), RCVec(RCVec),
+        LambdaCalleeInfo(LambdaCalleeInfo), VarNameToDevPtr(VarNameToDevPtr),
         GlobalLinkedBinaries(GlobalLinkedBinaries), DeviceArch(DeviceArch),
         CGOption(CGOption), DumpIR(DumpIR),
         RelinkGlobalsByCopy(RelinkGlobalsByCopy),
@@ -87,7 +88,7 @@ public:
     std::string KernelMangled = (KernelName + Suffix);
 
     proteus::specializeIR(*M, KernelName, Suffix, BlockDim, GridDim, RCIndices,
-                          RCVec, LambdaCalleeInfo, SpecializeArgs,
+                          RCTypes, RCVec, LambdaCalleeInfo, SpecializeArgs,
                           SpecializeDims, SpecializeLaunchBounds);
 
     replaceGlobalVariablesWithPointers(*M, VarNameToDevPtr);

--- a/include/proteus/Config.hpp
+++ b/include/proteus/Config.hpp
@@ -127,6 +127,7 @@ public:
   KernelCloneOption ProteusKernelClone;
   bool ProteusEnableTimers;
   CodegenOption ProteusCodegen;
+  bool ProteusTraceOutput;
 
 private:
   Config() {
@@ -169,6 +170,7 @@ private:
     ProteusKernelClone = getEnvOrDefaultKC("PROTEUS_KERNEL_CLONE",
                                            KernelCloneOption::CrossClone);
     ProteusEnableTimers = getEnvOrDefaultBool("PROTEUS_ENABLE_TIMERS", false);
+    ProteusTraceOutput = getEnvOrDefaultBool("PROTEUS_TRACE_OUTPUT", false);
   }
 };
 } // namespace proteus

--- a/include/proteus/JitEngineDevice.hpp
+++ b/include/proteus/JitEngineDevice.hpp
@@ -641,7 +641,7 @@ JitEngineDevice<ImplT>::compileAndRun(
 
       Compiler.compile(CompilationTask{
           KernelBitcode, HashValue, KernelInfo.getName(), Suffix, BlockDim,
-          GridDim, KernelInfo.getRCIndices(), RCVec,
+          GridDim, KernelInfo.getRCIndices(), KernelInfo.getRCTypes(), RCVec,
           KernelInfo.getLambdaCalleeInfo(), VarNameToDevPtr,
           GlobalLinkedBinaries, DeviceArch,
           /* CGOption */ Config::get().ProteusCodegen,
@@ -666,7 +666,7 @@ JitEngineDevice<ImplT>::compileAndRun(
     // Process through synchronous compilation.
     ObjBuf = CompilerSync::instance().compile(CompilationTask{
         KernelBitcode, HashValue, KernelInfo.getName(), Suffix, BlockDim,
-        GridDim, KernelInfo.getRCIndices(), RCVec,
+        GridDim, KernelInfo.getRCIndices(), KernelInfo.getRCTypes(), RCVec,
         KernelInfo.getLambdaCalleeInfo(), VarNameToDevPtr, GlobalLinkedBinaries,
         DeviceArch,
         /* CGOption */ Config::get().ProteusCodegen,

--- a/include/proteus/JitEngineHost.hpp
+++ b/include/proteus/JitEngineHost.hpp
@@ -41,7 +41,7 @@ public:
 
   Expected<orc::ThreadSafeModule>
   specializeIR(std::unique_ptr<Module> M, std::unique_ptr<LLVMContext> Ctx,
-               StringRef FnName, StringRef Suffix,
+               StringRef FnName, StringRef Suffix, ArrayRef<int32_t> RCTypes,
                const SmallVector<RuntimeConstant> &RCVec);
 
   void *compileAndLink(StringRef FnName, char *IR, int IRSize, void **Args,

--- a/include/proteus/Logger.hpp
+++ b/include/proteus/Logger.hpp
@@ -2,6 +2,7 @@
 #define PROTEUS_LOGGER_HPP
 
 #include <filesystem>
+#include <iostream>
 #include <stdexcept>
 #include <string>
 #include <system_error>
@@ -25,6 +26,8 @@ public:
     llvm::outs() << "[" << Name << "] ";
     return llvm::outs();
   }
+
+  static void trace(llvm::StringRef Msg) { std::cout << Msg.str(); }
 
   template <typename T>
   static void logfile(const std::string &Filename, T &&Data) {
@@ -51,6 +54,10 @@ private:
                                        EC, llvm::sys::fs::OF_None}) {
     if (EC)
       throw std::runtime_error("Error opening file: " + EC.message());
+
+    // Synchronize C++ streams with stdio for tracing (e.g., printf from GPU
+    // kernels).
+    std::ios::sync_with_stdio(true);
   }
 };
 

--- a/include/proteus/TransformLambdaSpecialization.hpp
+++ b/include/proteus/TransformLambdaSpecialization.hpp
@@ -72,6 +72,14 @@ public:
     }
 #endif
 
+    auto TraceOut = [](int Slot, Constant *C) {
+      SmallString<128> S;
+      raw_svector_ostream OS(S);
+      OS << "[LambdaSpec] Replacing slot " << Slot << " with " << *C << "\n";
+
+      return S;
+    };
+
     PROTEUS_DBG(Logger::logs("proteus") << "\t users" << "\n");
     for (User *User : LambdaClass->users()) {
       PROTEUS_DBG(Logger::logs("proteus") << *User << "\n");
@@ -80,9 +88,9 @@ public:
           if (Arg.Slot == 0) {
             Constant *C = getConstant(M.getContext(), User->getType(), Arg);
             User->replaceAllUsesWith(C);
-            PROTEUS_DBG(Logger::logs("proteus")
-                        << "[LambdaSpec] Replacing " << *User << " with " << *C
-                        << "\n");
+            PROTEUS_DBG(Logger::logs("proteus") << TraceOut(Arg.Slot, C));
+            if (Config::get().ProteusTraceOutput)
+              Logger::trace(TraceOut(Arg.Slot, C));
           }
         }
       } else if (auto *GEP = dyn_cast<GetElementPtrInst>(User)) {
@@ -98,9 +106,9 @@ public:
               Type *LoadType = LI->getType();
               Constant *C = getConstant(M.getContext(), LoadType, Arg);
               LI->replaceAllUsesWith(C);
-              PROTEUS_DBG(Logger::logs("proteus")
-                          << "[LambdaSpec] Replacing " << *User << " with "
-                          << *C << "\n");
+              PROTEUS_DBG(Logger::logs("proteus") << TraceOut(Arg.Slot, C));
+              if (Config::get().ProteusTraceOutput)
+                Logger::trace(TraceOut(Arg.Slot, C));
             }
           }
         }

--- a/include/proteus/TransformSharedArray.hpp
+++ b/include/proteus/TransformSharedArray.hpp
@@ -59,7 +59,8 @@ public:
           // TODO: Create or find an API to query the proper ABI alignment.
           SharedMemGV->setAlignment(Align{16});
 
-          auto TraceOut = [](StringRef DemangledName, GlobalVariable *SharedMemGV) {
+          auto TraceOut = [](StringRef DemangledName,
+                             GlobalVariable *SharedMemGV) {
             SmallString<128> S;
             raw_svector_ostream OS(S);
             OS << "[SharedArray] " << "Replace CB " << DemangledName << " with "
@@ -68,7 +69,8 @@ public:
             return S;
           };
 
-          PROTEUS_DBG(Logger::logs("proteus") << TraceOut(DemangledName, SharedMemGV));
+          PROTEUS_DBG(Logger::logs("proteus")
+                      << TraceOut(DemangledName, SharedMemGV));
           if (Config::get().ProteusTraceOutput)
             Logger::trace(TraceOut(DemangledName, SharedMemGV));
 

--- a/include/proteus/TransformSharedArray.hpp
+++ b/include/proteus/TransformSharedArray.hpp
@@ -59,18 +59,18 @@ public:
           // TODO: Create or find an API to query the proper ABI alignment.
           SharedMemGV->setAlignment(Align{16});
 
-          auto TraceOut = [](CallBase *CB, GlobalVariable *SharedMemGV) {
+          auto TraceOut = [](StringRef DemangledName, GlobalVariable *SharedMemGV) {
             SmallString<128> S;
             raw_svector_ostream OS(S);
-            OS << "[SharedArray] " << "Replace CB " << *CB << " with "
+            OS << "[SharedArray] " << "Replace CB " << DemangledName << " with "
                << *SharedMemGV << "\n";
 
             return S;
           };
 
-          PROTEUS_DBG(Logger::logs("proteus") << TraceOut(CB, SharedMemGV));
+          PROTEUS_DBG(Logger::logs("proteus") << TraceOut(DemangledName, SharedMemGV));
           if (Config::get().ProteusTraceOutput)
-            Logger::trace(TraceOut(CB, SharedMemGV));
+            Logger::trace(TraceOut(DemangledName, SharedMemGV));
 
           CB->replaceAllUsesWith(ConstantExpr::getAddrSpaceCast(
               SharedMemGV, CB->getFunctionType()->getReturnType()));

--- a/tests/cpu/CMakeLists.txt
+++ b/tests/cpu/CMakeLists.txt
@@ -22,6 +22,7 @@ function(CREATE_CPU_TEST exe check_source)
     )
 
     add_test(NAME ${exe} COMMAND ${LIT} -vv -D FILECHECK=${FILECHECK} ${check_source})
+    set_tests_properties(${exe} PROPERTIES LABELS "cpu")
 endfunction()
 
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/lit.cfg.py "

--- a/tests/cpu/daxpy.cpp
+++ b/tests/cpu/daxpy.cpp
@@ -1,5 +1,5 @@
 // RUN: rm -rf .proteus
-// RUN: ./daxpy | %FILECHECK %s --check-prefixes=CHECK
+// RUN: PROTEUS_TRACE_OUTPUT=1 ./daxpy | %FILECHECK %s --check-prefixes=CHECK
 // RUN: rm -rf .proteus
 
 #include <cstddef>
@@ -40,8 +40,13 @@ int main() {
   return 0;
 }
 
+// clang-format off
 // CHECK: 0
+// CHECK: [ArgSpec] Replaced Function _Z7myDaxpydPdS_m ArgNo 0 with value double 6.200000e+00
+// CHECK: [ArgSpec] Replaced Function _Z7myDaxpydPdS_m ArgNo 3 with value i64 1024
 // CHECK: 19.4767
+// CHECK: [ArgSpec] Replaced Function _Z7myDaxpydPdS_m ArgNo 0 with value double 1.000000e+00
+// CHECK: [ArgSpec] Replaced Function _Z7myDaxpydPdS_m ArgNo 3 with value i64 1024
 // CHECK: 22.6181
 // CHECK: JitCache hits 0 total 2
 // CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0

--- a/tests/cpu/lambda.cpp
+++ b/tests/cpu/lambda.cpp
@@ -1,5 +1,5 @@
 // RUN: rm -rf .proteus
-// RUN: ./lambda | %FILECHECK %s --check-prefixes=CHECK
+// RUN: PROTEUS_TRACE_OUTPUT=1 ./lambda | %FILECHECK %s --check-prefixes=CHECK
 // RUN: rm -rf .proteus
 
 #include <iostream>
@@ -46,7 +46,11 @@ int main() {
   return 0;
 }
 
+// clang-format off
 // CHECK: 0
+// CHECK: [LambdaSpec] Replacing slot 2 with double 1.484000e+00
+// CHECK: [LambdaSpec] Replacing slot 1 with double 3.140000e+00
+// CHECK: [LambdaSpec] Replacing slot 0 with i64 1024
 // CHECK: 1.46382
 // CHECK: JitCache hits 0 total 1
 // CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0

--- a/tests/cpu/lambda_def.cpp
+++ b/tests/cpu/lambda_def.cpp
@@ -1,6 +1,8 @@
+// clang-format off
 // RUN: rm -rf .proteus
 // RUN: PROTEUS_TRACE_OUTPUT=1 ./lambda_def | %FILECHECK %s --check-prefixes=CHECK
 // RUN: rm -rf .proteus
+// clang-format on
 
 #include <cstdio>
 

--- a/tests/cpu/lambda_def.cpp
+++ b/tests/cpu/lambda_def.cpp
@@ -1,5 +1,5 @@
 // RUN: rm -rf .proteus
-// RUN: ./lambda_def | %FILECHECK %s --check-prefixes=CHECK
+// RUN: PROTEUS_TRACE_OUTPUT=1 ./lambda_def | %FILECHECK %s --check-prefixes=CHECK
 // RUN: rm -rf .proteus
 
 #include <cstdio>
@@ -16,9 +16,8 @@ int main() {
 
   int A = 42;
   auto Lambda =
-      [ =, A = proteus::jit_variable(A) ]() __attribute__((annotate("jit"))) {
-    printf("Lambda A %d\n", A);
-  };
+      [=, A = proteus::jit_variable(A)]()
+          __attribute__((annotate("jit"))) { printf("Lambda A %d\n", A); };
   run(Lambda);
   run(Lambda);
   run(Lambda);
@@ -27,6 +26,8 @@ int main() {
   return 0;
 }
 
-// CHECK-3: Lambda 42
+// clang-format off
+// CHECK: [LambdaSpec] Replacing slot 0 with i32 42
+// CHECK-COUNT-3: Lambda A 42
 // CHECK: JitCache hits 2 total 3
 // CHECK: HashValue {{[0-9]+}} NumExecs 3 NumHits 2

--- a/tests/cpu/lambda_multiple.cpp
+++ b/tests/cpu/lambda_multiple.cpp
@@ -1,6 +1,6 @@
 // clang-format off
 // RUN: rm -rf .proteus
-// RUN: ./lambda_multiple | %FILECHECK %s --check-prefixes=CHECK
+// RUN: PROTEUS_TRACE_OUTPUT=1 ./lambda_multiple | %FILECHECK %s --check-prefixes=CHECK
 // RUN: rm -rf .proteus
 // clang-format on
 
@@ -16,7 +16,7 @@ template <typename F> void run(F &&Func) {
 }
 
 void lambdaCaller(int V) {
-  run([ =, V = proteus::jit_variable(V) ]()
+  run([=, V = proteus::jit_variable(V)]()
           __attribute__((annotate("jit"))) { printf("V %d\n", V); });
 }
 
@@ -39,11 +39,14 @@ int main() {
   proteus::finalize();
 }
 
+// CHECK: [LambdaSpec] Replacing slot 0 with i32 1
 // CHECK: V 1
+// CHECK: [ArgSpec] Replaced Function _Z3fooi ArgNo 0 with value i32 42
 // CHECK: foo 42
+// CHECK: [LambdaSpec] Replacing slot 0 with i32 2
 // CHECK: V 2
 // CHECK: V 1
 // CHECK: foo 42
 // CHECK: V 2
 // CHECK: JitCache hits 3 total 6
-// CHECK-3: HashValue {{[0-9]+}} NumExecs 2 NumHits 1
+// CHECK-COUNT-3: HashValue {{[0-9]+}} NumExecs 2 NumHits 1

--- a/tests/cpu/types.cpp
+++ b/tests/cpu/types.cpp
@@ -53,7 +53,7 @@ int main() {
 // CHECK: Arg 7
 // CHECK: [ArgSpec] Replaced Function _Z4testIdEvT_ ArgNo 0 with value double 8.000000e+00
 // CHECK: Arg 8
-// CHECK: [ArgSpec] Replaced Function _Z4testIeEvT_ ArgNo 0 with value {{x86_fp80 0xK40029000000000000000|ppc_fp128 0xM40220000000000000000000000000000}}
+// CHECK: [ArgSpec] Replaced Function _Z4testI{{e|g}}EvT_ ArgNo 0 with value {{x86_fp80 0xK40029000000000000000|ppc_fp128 0xM40220000000000000000000000000000}}
 // CHECK: Arg 9
 // CHECK: [ArgSpec] Replaced Function _Z4testIbEvT_ ArgNo 0 with value i1 true
 // CHECK: Arg 1

--- a/tests/cpu/types.cpp
+++ b/tests/cpu/types.cpp
@@ -1,5 +1,5 @@
 // RUN: rm -rf .proteus
-// RUN: ./types | %FILECHECK %s --check-prefixes=CHECK
+// RUN: PROTEUS_TRACE_OUTPUT=1 ./types | %FILECHECK %s --check-prefixes=CHECK
 // RUN: rm -rf .proteus
 
 #include <cstdlib>
@@ -36,18 +36,32 @@ int main() {
   return 0;
 }
 
+// clang-format off
+// CHECK: [ArgSpec] Replaced Function _Z4testIiEvT_ ArgNo 0 with value i32 1
 // CHECK: Arg 1
+// CHECK: [ArgSpec] Replaced Function _Z4testIlEvT_ ArgNo 0 with value i64 2
 // CHECK: Arg 2
+// CHECK: [ArgSpec] Replaced Function _Z4testIjEvT_ ArgNo 0 with value i32 3
 // CHECK: Arg 3
+// CHECK: [ArgSpec] Replaced Function _Z4testImEvT_ ArgNo 0 with value i64 4
 // CHECK: Arg 4
+// CHECK: [ArgSpec] Replaced Function _Z4testIxEvT_ ArgNo 0 with value i64 5
 // CHECK: Arg 5
+// CHECK: [ArgSpec] Replaced Function _Z4testIyEvT_ ArgNo 0 with value i64 6
 // CHECK: Arg 6
+// CHECK: [ArgSpec] Replaced Function _Z4testIfEvT_ ArgNo 0 with value float 7.000000e+00
 // CHECK: Arg 7
+// CHECK: [ArgSpec] Replaced Function _Z4testIdEvT_ ArgNo 0 with value double 8.000000e+00
 // CHECK: Arg 8
+// CHECK: [ArgSpec] Replaced Function _Z4testIeEvT_ ArgNo 0 with value {{x86_fp80 0xK40029000000000000000|ppc_fp128 0xM40220000000000000000000000000000}}
 // CHECK: Arg 9
+// CHECK: [ArgSpec] Replaced Function _Z4testIbEvT_ ArgNo 0 with value i1 true
 // CHECK: Arg 1
+// CHECK: [ArgSpec] Replaced Function _Z4testIcEvT_ ArgNo 0 with value i8 97
 // CHECK: Arg a
+// CHECK: [ArgSpec] Replaced Function _Z4testIhEvT_ ArgNo 0 with value i8 97
 // CHECK: Arg a
+// CHECK: [ArgSpec] Replaced Function _Z4testIPiEvT_ ArgNo 0 with value ptr inttoptr (i64 291 to ptr)
 // CHECK: Arg 0x123
 // CHECK: JitCache hits 0 total 13
 // CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0

--- a/tests/gpu/CMakeLists.txt
+++ b/tests/gpu/CMakeLists.txt
@@ -25,6 +25,7 @@ function(CREATE_GPU_TEST exe check_source)
 
     # set_target_properties(${exe}.${lang} PROPERTIES CUDA_RUNTIME_LIBRARY Shared)
     add_test(NAME ${exe}.${lang} COMMAND ${LIT} -vv -D EXT=${lang} -DFILECHECK=${FILECHECK} ${check_source})
+    set_tests_properties(${exe}.${lang} PROPERTIES LABELS "gpu;gpu-basic")
 endfunction()
 
 function(CREATE_GPU_TEST_RDC exe check_source)
@@ -78,6 +79,7 @@ function(CREATE_GPU_TEST_RDC exe check_source)
     endif()
 
     add_test(NAME ${exe}.${lang}.rdc COMMAND ${LIT} -vv -D EXT=${lang}.rdc -DFILECHECK=${FILECHECK} ${check_source})
+    set_tests_properties(${exe}.${lang}.rdc PROPERTIES LABELS "gpu;gpu-rdc")
 endfunction()
 
 function(CREATE_GPU_TEST_RDC_LIBS exe libs check_source)

--- a/tests/gpu/alias_gvar.cpp
+++ b/tests/gpu/alias_gvar.cpp
@@ -56,10 +56,6 @@ int main() {
 }
 
 // clang-format off
-// CHECK-FIRST: [DimSpec] Replace call to _ZL21__hip_get_block_dim_xv with constant i32 256
-// CHECK-FIRST: [DimSpec] Assume llvm.amdgcn.workitem.id.x with 256
-// CHECK-FIRST: [DimSpec] Assume llvm.amdgcn.workgroup.id.x with 4
-// CHECK-FIRST: [LaunchBoundSpec] GridSize 4 BlockSize 256
 // CHECK: First 5 elements: 0 2 4 6 8
 // CHECK: JitCache hits 0 total 1
 // CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0

--- a/tests/gpu/alias_gvar.cpp
+++ b/tests/gpu/alias_gvar.cpp
@@ -1,6 +1,6 @@
 // clang-format off
 // RUN: rm -rf .proteus
-// RUN: ./alias_gvar.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: PROTEUS_TRACE_OUTPUT=1 ./alias_gvar.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
 // RUN: ./alias_gvar.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
 // RUN: rm -rf .proteus
@@ -55,6 +55,11 @@ int main() {
   return 0;
 }
 
+// clang-format off
+// CHECK-FIRST: [DimSpec] Replace call to _ZL21__hip_get_block_dim_xv with constant i32 256
+// CHECK-FIRST: [DimSpec] Assume llvm.amdgcn.workitem.id.x with 256
+// CHECK-FIRST: [DimSpec] Assume llvm.amdgcn.workgroup.id.x with 4
+// CHECK-FIRST: [LaunchBoundSpec] GridSize 4 BlockSize 256
 // CHECK: First 5 elements: 0 2 4 6 8
 // CHECK: JitCache hits 0 total 1
 // CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0

--- a/tests/gpu/block_grid_dim_1d.cpp
+++ b/tests/gpu/block_grid_dim_1d.cpp
@@ -1,6 +1,6 @@
 // clang-format off
 // RUN: rm -rf .proteus
-// RUN: ./block_grid_dim_1d.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: PROTEUS_TRACE_OUTPUT=1 ./block_grid_dim_1d.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
 // RUN: ./block_grid_dim_1d.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
 // RUN: rm -rf .proteus
@@ -27,83 +27,88 @@ __global__ __attribute__((annotate("jit"))) void kernel() {
 int main() {
   proteus::init();
 
-  for (int Tid = 1; Tid <= 32; Tid++) {
-    dim3 BlockDim(Tid * 32, 1, 1);
-    dim3 GridDim(Tid, 1, 1);
+  for (int Tid = 64; Tid <= 1024; Tid *= 2) {
+    dim3 BlockDim(Tid, 1, 1);
+    dim3 GridDim(Tid / 64, 1, 1);
     kernel<<<GridDim, BlockDim>>>();
+    gpuErrCheck(gpuDeviceSynchronize());
   }
-  gpuErrCheck(gpuDeviceSynchronize());
 
   proteus::finalize();
   return 0;
 }
 
 // clang-format off
-// CHECK:ThreadId: (31 0 0) BlockID: (0 0 0) BlockDim: (32 1 1) GridDim: (1 1 1)
-// CHECK:ThreadId: (63 0 0) BlockID: (1 0 0) BlockDim: (64 1 1) GridDim: (2 1 1)
-// CHECK:ThreadId: (95 0 0) BlockID: (2 0 0) BlockDim: (96 1 1) GridDim: (3 1 1)
-// CHECK:ThreadId: (127 0 0) BlockID: (3 0 0) BlockDim: (128 1 1) GridDim: (4 1 1)
-// CHECK:ThreadId: (159 0 0) BlockID: (4 0 0) BlockDim: (160 1 1) GridDim: (5 1 1)
-// CHECK:ThreadId: (191 0 0) BlockID: (5 0 0) BlockDim: (192 1 1) GridDim: (6 1 1)
-// CHECK:ThreadId: (223 0 0) BlockID: (6 0 0) BlockDim: (224 1 1) GridDim: (7 1 1)
-// CHECK:ThreadId: (255 0 0) BlockID: (7 0 0) BlockDim: (256 1 1) GridDim: (8 1 1)
-// CHECK:ThreadId: (287 0 0) BlockID: (8 0 0) BlockDim: (288 1 1) GridDim: (9 1 1)
-// CHECK:ThreadId: (319 0 0) BlockID: (9 0 0) BlockDim: (320 1 1) GridDim: (10 1 1)
-// CHECK:ThreadId: (351 0 0) BlockID: (10 0 0) BlockDim: (352 1 1) GridDim: (11 1 1)
-// CHECK:ThreadId: (383 0 0) BlockID: (11 0 0) BlockDim: (384 1 1) GridDim: (12 1 1)
-// CHECK:ThreadId: (415 0 0) BlockID: (12 0 0) BlockDim: (416 1 1) GridDim: (13 1 1)
-// CHECK:ThreadId: (447 0 0) BlockID: (13 0 0) BlockDim: (448 1 1) GridDim: (14 1 1)
-// CHECK:ThreadId: (479 0 0) BlockID: (14 0 0) BlockDim: (480 1 1) GridDim: (15 1 1)
-// CHECK:ThreadId: (511 0 0) BlockID: (15 0 0) BlockDim: (512 1 1) GridDim: (16 1 1)
-// CHECK:ThreadId: (543 0 0) BlockID: (16 0 0) BlockDim: (544 1 1) GridDim: (17 1 1)
-// CHECK:ThreadId: (575 0 0) BlockID: (17 0 0) BlockDim: (576 1 1) GridDim: (18 1 1)
-// CHECK:ThreadId: (607 0 0) BlockID: (18 0 0) BlockDim: (608 1 1) GridDim: (19 1 1)
-// CHECK:ThreadId: (639 0 0) BlockID: (19 0 0) BlockDim: (640 1 1) GridDim: (20 1 1)
-// CHECK:ThreadId: (671 0 0) BlockID: (20 0 0) BlockDim: (672 1 1) GridDim: (21 1 1)
-// CHECK:ThreadId: (703 0 0) BlockID: (21 0 0) BlockDim: (704 1 1) GridDim: (22 1 1)
-// CHECK:ThreadId: (735 0 0) BlockID: (22 0 0) BlockDim: (736 1 1) GridDim: (23 1 1)
-// CHECK:ThreadId: (767 0 0) BlockID: (23 0 0) BlockDim: (768 1 1) GridDim: (24 1 1)
-// CHECK:ThreadId: (799 0 0) BlockID: (24 0 0) BlockDim: (800 1 1) GridDim: (25 1 1)
-// CHECK:ThreadId: (831 0 0) BlockID: (25 0 0) BlockDim: (832 1 1) GridDim: (26 1 1)
-// CHECK:ThreadId: (863 0 0) BlockID: (26 0 0) BlockDim: (864 1 1) GridDim: (27 1 1)
-// CHECK:ThreadId: (895 0 0) BlockID: (27 0 0) BlockDim: (896 1 1) GridDim: (28 1 1)
-// CHECK:ThreadId: (927 0 0) BlockID: (28 0 0) BlockDim: (928 1 1) GridDim: (29 1 1)
-// CHECK:ThreadId: (959 0 0) BlockID: (29 0 0) BlockDim: (960 1 1) GridDim: (30 1 1)
-// CHECK:ThreadId: (991 0 0) BlockID: (30 0 0) BlockDim: (992 1 1) GridDim: (31 1 1)
-// CHECK:ThreadId: (1023 0 0) BlockID: (31 0 0) BlockDim: (1024 1 1) GridDim: (32 1 1)
-
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-// CHECK-FIRST: JitStorageCache hits 0 total 32
-// CHECK-SECOND: JitStorageCache hits 32 total 32
-// clang-format on
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_xv|llvm.nvvm.read.ptx.sreg.nctaid.x}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_yv|llvm.nvvm.read.ptx.sreg.nctaid.y}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_zv|llvm.nvvm.read.ptx.sreg.nctaid.z}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_xv|llvm.nvvm.read.ptx.sreg.ntid.x}} with constant i32 64
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_yv|llvm.nvvm.read.ptx.sreg.ntid.y}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_zv|llvm.nvvm.read.ptx.sreg.ntid.z}} with constant i32 1
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [LaunchBoundSpec] GridSize 1 BlockSize 64
+// CHECK: ThreadId: (63 0 0) BlockID: (0 0 0) BlockDim: (64 1 1) GridDim: (1 1 1)
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_xv|llvm.nvvm.read.ptx.sreg.nctaid.x}} with constant i32 2
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_yv|llvm.nvvm.read.ptx.sreg.nctaid.y}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_zv|llvm.nvvm.read.ptx.sreg.nctaid.z}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_xv|llvm.nvvm.read.ptx.sreg.ntid.x}} with constant i32 128
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_yv|llvm.nvvm.read.ptx.sreg.ntid.y}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_zv|llvm.nvvm.read.ptx.sreg.ntid.z}} with constant i32 1
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [LaunchBoundSpec] GridSize 2 BlockSize 128
+// CHECK: ThreadId: (127 0 0) BlockID: (1 0 0) BlockDim: (128 1 1) GridDim: (2 1 1)
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_xv|llvm.nvvm.read.ptx.sreg.nctaid.x}} with constant i32 4
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_yv|llvm.nvvm.read.ptx.sreg.nctaid.y}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_zv|llvm.nvvm.read.ptx.sreg.nctaid.z}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_xv|llvm.nvvm.read.ptx.sreg.ntid.x}} with constant i32 256
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_yv|llvm.nvvm.read.ptx.sreg.ntid.y}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_zv|llvm.nvvm.read.ptx.sreg.ntid.z}} with constant i32 1
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [LaunchBoundSpec] GridSize 4 BlockSize 256
+// CHECK: ThreadId: (255 0 0) BlockID: (3 0 0) BlockDim: (256 1 1) GridDim: (4 1 1)
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_xv|llvm.nvvm.read.ptx.sreg.nctaid.x}} with constant i32 8
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_yv|llvm.nvvm.read.ptx.sreg.nctaid.y}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_zv|llvm.nvvm.read.ptx.sreg.nctaid.z}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_xv|llvm.nvvm.read.ptx.sreg.ntid.x}} with constant i32 512
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_yv|llvm.nvvm.read.ptx.sreg.ntid.y}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_zv|llvm.nvvm.read.ptx.sreg.ntid.z}} with constant i32 1
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [LaunchBoundSpec] GridSize 8 BlockSize 512
+// CHECK: ThreadId: (511 0 0) BlockID: (7 0 0) BlockDim: (512 1 1) GridDim: (8 1 1)
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_xv|llvm.nvvm.read.ptx.sreg.nctaid.x}} with constant i32 16
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_yv|llvm.nvvm.read.ptx.sreg.nctaid.y}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_zv|llvm.nvvm.read.ptx.sreg.nctaid.z}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_xv|llvm.nvvm.read.ptx.sreg.ntid.x}} with constant i32 1024
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_yv|llvm.nvvm.read.ptx.sreg.ntid.y}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_zv|llvm.nvvm.read.ptx.sreg.ntid.z}} with constant i32 1
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [LaunchBoundSpec] GridSize 16 BlockSize 1024
+// CHECK: ThreadId: (1023 0 0) BlockID: (15 0 0) BlockDim: (1024 1 1) GridDim: (16 1 1)
+// CHECK-COUNT-5: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
+// CHECK-FIRST: JitStorageCache hits 0 total 5
+// CHECK-SECOND: JitStorageCache hits 5 total 5

--- a/tests/gpu/block_grid_dim_1d.cpp
+++ b/tests/gpu/block_grid_dim_1d.cpp
@@ -39,12 +39,12 @@ int main() {
 }
 
 // clang-format off
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_xv|llvm.nvvm.read.ptx.sreg.nctaid.x}} with constant i32 1
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_yv|llvm.nvvm.read.ptx.sreg.nctaid.y}} with constant i32 1
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_zv|llvm.nvvm.read.ptx.sreg.nctaid.z}} with constant i32 1
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_xv|llvm.nvvm.read.ptx.sreg.ntid.x}} with constant i32 64
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_yv|llvm.nvvm.read.ptx.sreg.ntid.y}} with constant i32 1
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_zv|llvm.nvvm.read.ptx.sreg.ntid.z}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI13__HIP_GridDimE3__XcvjEv|_ZL20__hip_get_grid_dim_xv|llvm.nvvm.read.ptx.sreg.nctaid.x}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI13__HIP_GridDimE3__YcvjEv|_ZL20__hip_get_grid_dim_yv|llvm.nvvm.read.ptx.sreg.nctaid.y}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI13__HIP_GridDimE3__ZcvjEv|_ZL20__hip_get_grid_dim_zv|llvm.nvvm.read.ptx.sreg.nctaid.z}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI14__HIP_BlockDimE3__XcvjEv|_ZL21__hip_get_block_dim_xv|llvm.nvvm.read.ptx.sreg.ntid.x}} with constant i32 64
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI14__HIP_BlockDimE3__YcvjEv|_ZL21__hip_get_block_dim_yv|llvm.nvvm.read.ptx.sreg.ntid.y}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI14__HIP_BlockDimE3__ZcvjEv|_ZL21__hip_get_block_dim_zv|llvm.nvvm.read.ptx.sreg.ntid.z}} with constant i32 1
 // CHECK-FIRST: [DimSpec]
 // CHECK-FIRST: [DimSpec]
 // CHECK-FIRST: [DimSpec]
@@ -53,12 +53,12 @@ int main() {
 // CHECK-FIRST: [DimSpec]
 // CHECK-FIRST: [LaunchBoundSpec] GridSize 1 BlockSize 64
 // CHECK: ThreadId: (63 0 0) BlockID: (0 0 0) BlockDim: (64 1 1) GridDim: (1 1 1)
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_xv|llvm.nvvm.read.ptx.sreg.nctaid.x}} with constant i32 2
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_yv|llvm.nvvm.read.ptx.sreg.nctaid.y}} with constant i32 1
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_zv|llvm.nvvm.read.ptx.sreg.nctaid.z}} with constant i32 1
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_xv|llvm.nvvm.read.ptx.sreg.ntid.x}} with constant i32 128
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_yv|llvm.nvvm.read.ptx.sreg.ntid.y}} with constant i32 1
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_zv|llvm.nvvm.read.ptx.sreg.ntid.z}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI13__HIP_GridDimE3__XcvjEv|_ZL20__hip_get_grid_dim_xv|llvm.nvvm.read.ptx.sreg.nctaid.x}} with constant i32 2
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI13__HIP_GridDimE3__YcvjEv|_ZL20__hip_get_grid_dim_yv|llvm.nvvm.read.ptx.sreg.nctaid.y}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI13__HIP_GridDimE3__ZcvjEv|_ZL20__hip_get_grid_dim_zv|llvm.nvvm.read.ptx.sreg.nctaid.z}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI14__HIP_BlockDimE3__XcvjEv|_ZL21__hip_get_block_dim_xv|llvm.nvvm.read.ptx.sreg.ntid.x}} with constant i32 128
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI14__HIP_BlockDimE3__YcvjEv|_ZL21__hip_get_block_dim_yv|llvm.nvvm.read.ptx.sreg.ntid.y}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI14__HIP_BlockDimE3__ZcvjEv|_ZL21__hip_get_block_dim_zv|llvm.nvvm.read.ptx.sreg.ntid.z}} with constant i32 1
 // CHECK-FIRST: [DimSpec]
 // CHECK-FIRST: [DimSpec]
 // CHECK-FIRST: [DimSpec]
@@ -67,12 +67,12 @@ int main() {
 // CHECK-FIRST: [DimSpec]
 // CHECK-FIRST: [LaunchBoundSpec] GridSize 2 BlockSize 128
 // CHECK: ThreadId: (127 0 0) BlockID: (1 0 0) BlockDim: (128 1 1) GridDim: (2 1 1)
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_xv|llvm.nvvm.read.ptx.sreg.nctaid.x}} with constant i32 4
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_yv|llvm.nvvm.read.ptx.sreg.nctaid.y}} with constant i32 1
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_zv|llvm.nvvm.read.ptx.sreg.nctaid.z}} with constant i32 1
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_xv|llvm.nvvm.read.ptx.sreg.ntid.x}} with constant i32 256
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_yv|llvm.nvvm.read.ptx.sreg.ntid.y}} with constant i32 1
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_zv|llvm.nvvm.read.ptx.sreg.ntid.z}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI13__HIP_GridDimE3__XcvjEv|_ZL20__hip_get_grid_dim_xv|llvm.nvvm.read.ptx.sreg.nctaid.x}} with constant i32 4
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI13__HIP_GridDimE3__YcvjEv|_ZL20__hip_get_grid_dim_yv|llvm.nvvm.read.ptx.sreg.nctaid.y}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI13__HIP_GridDimE3__ZcvjEv|_ZL20__hip_get_grid_dim_zv|llvm.nvvm.read.ptx.sreg.nctaid.z}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI14__HIP_BlockDimE3__XcvjEv|_ZL21__hip_get_block_dim_xv|llvm.nvvm.read.ptx.sreg.ntid.x}} with constant i32 256
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI14__HIP_BlockDimE3__YcvjEv|_ZL21__hip_get_block_dim_yv|llvm.nvvm.read.ptx.sreg.ntid.y}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI14__HIP_BlockDimE3__ZcvjEv|_ZL21__hip_get_block_dim_zv|llvm.nvvm.read.ptx.sreg.ntid.z}} with constant i32 1
 // CHECK-FIRST: [DimSpec]
 // CHECK-FIRST: [DimSpec]
 // CHECK-FIRST: [DimSpec]
@@ -81,12 +81,12 @@ int main() {
 // CHECK-FIRST: [DimSpec]
 // CHECK-FIRST: [LaunchBoundSpec] GridSize 4 BlockSize 256
 // CHECK: ThreadId: (255 0 0) BlockID: (3 0 0) BlockDim: (256 1 1) GridDim: (4 1 1)
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_xv|llvm.nvvm.read.ptx.sreg.nctaid.x}} with constant i32 8
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_yv|llvm.nvvm.read.ptx.sreg.nctaid.y}} with constant i32 1
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_zv|llvm.nvvm.read.ptx.sreg.nctaid.z}} with constant i32 1
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_xv|llvm.nvvm.read.ptx.sreg.ntid.x}} with constant i32 512
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_yv|llvm.nvvm.read.ptx.sreg.ntid.y}} with constant i32 1
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_zv|llvm.nvvm.read.ptx.sreg.ntid.z}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI13__HIP_GridDimE3__XcvjEv|_ZL20__hip_get_grid_dim_xv|llvm.nvvm.read.ptx.sreg.nctaid.x}} with constant i32 8
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI13__HIP_GridDimE3__YcvjEv|_ZL20__hip_get_grid_dim_yv|llvm.nvvm.read.ptx.sreg.nctaid.y}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI13__HIP_GridDimE3__ZcvjEv|_ZL20__hip_get_grid_dim_zv|llvm.nvvm.read.ptx.sreg.nctaid.z}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI14__HIP_BlockDimE3__XcvjEv|_ZL21__hip_get_block_dim_xv|llvm.nvvm.read.ptx.sreg.ntid.x}} with constant i32 512
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI14__HIP_BlockDimE3__YcvjEv|_ZL21__hip_get_block_dim_yv|llvm.nvvm.read.ptx.sreg.ntid.y}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI14__HIP_BlockDimE3__ZcvjEv|_ZL21__hip_get_block_dim_zv|llvm.nvvm.read.ptx.sreg.ntid.z}} with constant i32 1
 // CHECK-FIRST: [DimSpec]
 // CHECK-FIRST: [DimSpec]
 // CHECK-FIRST: [DimSpec]
@@ -95,12 +95,12 @@ int main() {
 // CHECK-FIRST: [DimSpec]
 // CHECK-FIRST: [LaunchBoundSpec] GridSize 8 BlockSize 512
 // CHECK: ThreadId: (511 0 0) BlockID: (7 0 0) BlockDim: (512 1 1) GridDim: (8 1 1)
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_xv|llvm.nvvm.read.ptx.sreg.nctaid.x}} with constant i32 16
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_yv|llvm.nvvm.read.ptx.sreg.nctaid.y}} with constant i32 1
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_zv|llvm.nvvm.read.ptx.sreg.nctaid.z}} with constant i32 1
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_xv|llvm.nvvm.read.ptx.sreg.ntid.x}} with constant i32 1024
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_yv|llvm.nvvm.read.ptx.sreg.ntid.y}} with constant i32 1
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_zv|llvm.nvvm.read.ptx.sreg.ntid.z}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI13__HIP_GridDimE3__XcvjEv|_ZL20__hip_get_grid_dim_xv|llvm.nvvm.read.ptx.sreg.nctaid.x}} with constant i32 16
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI13__HIP_GridDimE3__YcvjEv|_ZL20__hip_get_grid_dim_yv|llvm.nvvm.read.ptx.sreg.nctaid.y}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI13__HIP_GridDimE3__ZcvjEv|_ZL20__hip_get_grid_dim_zv|llvm.nvvm.read.ptx.sreg.nctaid.z}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI14__HIP_BlockDimE3__XcvjEv|_ZL21__hip_get_block_dim_xv|llvm.nvvm.read.ptx.sreg.ntid.x}} with constant i32 1024
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI14__HIP_BlockDimE3__YcvjEv|_ZL21__hip_get_block_dim_yv|llvm.nvvm.read.ptx.sreg.ntid.y}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI14__HIP_BlockDimE3__ZcvjEv|_ZL21__hip_get_block_dim_zv|llvm.nvvm.read.ptx.sreg.ntid.z}} with constant i32 1
 // CHECK-FIRST: [DimSpec]
 // CHECK-FIRST: [DimSpec]
 // CHECK-FIRST: [DimSpec]

--- a/tests/gpu/block_grid_dim_2d.cpp
+++ b/tests/gpu/block_grid_dim_2d.cpp
@@ -39,12 +39,12 @@ int main() {
 }
 
 // clang-format off
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_xv|llvm.nvvm.read.ptx.sreg.nctaid.x}} with constant i32 1
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_yv|llvm.nvvm.read.ptx.sreg.nctaid.y}} with constant i32 1
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_zv|llvm.nvvm.read.ptx.sreg.nctaid.z}} with constant i32 1
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_xv|llvm.nvvm.read.ptx.sreg.ntid.x}}  with constant i32 1
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_yv|llvm.nvvm.read.ptx.sreg.ntid.y}}  with constant i32 64
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_zv|llvm.nvvm.read.ptx.sreg.ntid.z}}  with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI13__HIP_GridDimE3__XcvjEv|_ZL20__hip_get_grid_dim_xv|llvm.nvvm.read.ptx.sreg.nctaid.x}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI13__HIP_GridDimE3__YcvjEv|_ZL20__hip_get_grid_dim_yv|llvm.nvvm.read.ptx.sreg.nctaid.y}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI13__HIP_GridDimE3__ZcvjEv|_ZL20__hip_get_grid_dim_zv|llvm.nvvm.read.ptx.sreg.nctaid.z}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI14__HIP_BlockDimE3__XcvjEv|_ZL21__hip_get_block_dim_xv|llvm.nvvm.read.ptx.sreg.ntid.x}}  with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI14__HIP_BlockDimE3__YcvjEv|_ZL21__hip_get_block_dim_yv|llvm.nvvm.read.ptx.sreg.ntid.y}}  with constant i32 64
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI14__HIP_BlockDimE3__ZcvjEv|_ZL21__hip_get_block_dim_zv|llvm.nvvm.read.ptx.sreg.ntid.z}}  with constant i32 1
 // CHECK-FIRST: [DimSpec]
 // CHECK-FIRST: [DimSpec]
 // CHECK-FIRST: [DimSpec]
@@ -53,12 +53,12 @@ int main() {
 // CHECK-FIRST: [DimSpec]
 // CHECK-FIRST: [LaunchBoundSpec] GridSize 1 BlockSize 64
 // CHECK: ThreadId: (0 63 0) BlockID: (0 0 0) BlockDim: (1 64 1) GridDim: (1 1 1)
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_xv|llvm.nvvm.read.ptx.sreg.nctaid.x}} with constant i32 1
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_yv|llvm.nvvm.read.ptx.sreg.nctaid.y}} with constant i32 2
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_zv|llvm.nvvm.read.ptx.sreg.nctaid.z}} with constant i32 1
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_xv|llvm.nvvm.read.ptx.sreg.ntid.x}}  with constant i32 1
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_yv|llvm.nvvm.read.ptx.sreg.ntid.y}}  with constant i32 128
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_zv|llvm.nvvm.read.ptx.sreg.ntid.z}}  with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI13__HIP_GridDimE3__XcvjEv|_ZL20__hip_get_grid_dim_xv|llvm.nvvm.read.ptx.sreg.nctaid.x}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI13__HIP_GridDimE3__YcvjEv|_ZL20__hip_get_grid_dim_yv|llvm.nvvm.read.ptx.sreg.nctaid.y}} with constant i32 2
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI13__HIP_GridDimE3__ZcvjEv|_ZL20__hip_get_grid_dim_zv|llvm.nvvm.read.ptx.sreg.nctaid.z}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI14__HIP_BlockDimE3__XcvjEv|_ZL21__hip_get_block_dim_xv|llvm.nvvm.read.ptx.sreg.ntid.x}}  with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI14__HIP_BlockDimE3__YcvjEv|_ZL21__hip_get_block_dim_yv|llvm.nvvm.read.ptx.sreg.ntid.y}}  with constant i32 128
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI14__HIP_BlockDimE3__ZcvjEv|_ZL21__hip_get_block_dim_zv|llvm.nvvm.read.ptx.sreg.ntid.z}}  with constant i32 1
 // CHECK-FIRST: [DimSpec]
 // CHECK-FIRST: [DimSpec]
 // CHECK-FIRST: [DimSpec]
@@ -67,12 +67,12 @@ int main() {
 // CHECK-FIRST: [DimSpec]
 // CHECK-FIRST: [LaunchBoundSpec] GridSize 2 BlockSize 128
 // CHECK: ThreadId: (0 127 0) BlockID: (0 1 0) BlockDim: (1 128 1) GridDim: (1 2 1)
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_xv|llvm.nvvm.read.ptx.sreg.nctaid.x}} with constant i32 1
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_yv|llvm.nvvm.read.ptx.sreg.nctaid.y}} with constant i32 4
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_zv|llvm.nvvm.read.ptx.sreg.nctaid.z}} with constant i32 1
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_xv|llvm.nvvm.read.ptx.sreg.ntid.x}}  with constant i32 1
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_yv|llvm.nvvm.read.ptx.sreg.ntid.y}}  with constant i32 256
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_zv|llvm.nvvm.read.ptx.sreg.ntid.z}}  with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI13__HIP_GridDimE3__XcvjEv|_ZL20__hip_get_grid_dim_xv|llvm.nvvm.read.ptx.sreg.nctaid.x}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI13__HIP_GridDimE3__YcvjEv|_ZL20__hip_get_grid_dim_yv|llvm.nvvm.read.ptx.sreg.nctaid.y}} with constant i32 4
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI13__HIP_GridDimE3__ZcvjEv|_ZL20__hip_get_grid_dim_zv|llvm.nvvm.read.ptx.sreg.nctaid.z}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI14__HIP_BlockDimE3__XcvjEv|_ZL21__hip_get_block_dim_xv|llvm.nvvm.read.ptx.sreg.ntid.x}}  with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI14__HIP_BlockDimE3__YcvjEv|_ZL21__hip_get_block_dim_yv|llvm.nvvm.read.ptx.sreg.ntid.y}}  with constant i32 256
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI14__HIP_BlockDimE3__ZcvjEv|_ZL21__hip_get_block_dim_zv|llvm.nvvm.read.ptx.sreg.ntid.z}}  with constant i32 1
 // CHECK-FIRST: [DimSpec]
 // CHECK-FIRST: [DimSpec]
 // CHECK-FIRST: [DimSpec]
@@ -81,12 +81,12 @@ int main() {
 // CHECK-FIRST: [DimSpec]
 // CHECK-FIRST: [LaunchBoundSpec] GridSize 4 BlockSize 256
 // CHECK: ThreadId: (0 255 0) BlockID: (0 3 0) BlockDim: (1 256 1) GridDim: (1 4 1)
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_xv|llvm.nvvm.read.ptx.sreg.nctaid.x}} with constant i32 1
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_yv|llvm.nvvm.read.ptx.sreg.nctaid.y}} with constant i32 8
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_zv|llvm.nvvm.read.ptx.sreg.nctaid.z}} with constant i32 1
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_xv|llvm.nvvm.read.ptx.sreg.ntid.x}}  with constant i32 1
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_yv|llvm.nvvm.read.ptx.sreg.ntid.y}}  with constant i32 512
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_zv|llvm.nvvm.read.ptx.sreg.ntid.z}}  with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI13__HIP_GridDimE3__XcvjEv|_ZL20__hip_get_grid_dim_xv|llvm.nvvm.read.ptx.sreg.nctaid.x}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI13__HIP_GridDimE3__YcvjEv|_ZL20__hip_get_grid_dim_yv|llvm.nvvm.read.ptx.sreg.nctaid.y}} with constant i32 8
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI13__HIP_GridDimE3__ZcvjEv|_ZL20__hip_get_grid_dim_zv|llvm.nvvm.read.ptx.sreg.nctaid.z}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI14__HIP_BlockDimE3__XcvjEv|_ZL21__hip_get_block_dim_xv|llvm.nvvm.read.ptx.sreg.ntid.x}}  with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI14__HIP_BlockDimE3__YcvjEv|_ZL21__hip_get_block_dim_yv|llvm.nvvm.read.ptx.sreg.ntid.y}}  with constant i32 512
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI14__HIP_BlockDimE3__ZcvjEv|_ZL21__hip_get_block_dim_zv|llvm.nvvm.read.ptx.sreg.ntid.z}}  with constant i32 1
 // CHECK-FIRST: [DimSpec]
 // CHECK-FIRST: [DimSpec]
 // CHECK-FIRST: [DimSpec]
@@ -95,12 +95,12 @@ int main() {
 // CHECK-FIRST: [DimSpec]
 // CHECK-FIRST: [LaunchBoundSpec] GridSize 8 BlockSize 512
 // CHECK: ThreadId: (0 511 0) BlockID: (0 7 0) BlockDim: (1 512 1) GridDim: (1 8 1)
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_xv|llvm.nvvm.read.ptx.sreg.nctaid.x}} with constant i32 1
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_yv|llvm.nvvm.read.ptx.sreg.nctaid.y}} with constant i32 16
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_zv|llvm.nvvm.read.ptx.sreg.nctaid.z}} with constant i32 1
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_xv|llvm.nvvm.read.ptx.sreg.ntid.x}}  with constant i32 1
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_yv|llvm.nvvm.read.ptx.sreg.ntid.y}}  with constant i32 1024
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_zv|llvm.nvvm.read.ptx.sreg.ntid.z}}  with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI13__HIP_GridDimE3__XcvjEv|_ZL20__hip_get_grid_dim_xv|llvm.nvvm.read.ptx.sreg.nctaid.x}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI13__HIP_GridDimE3__YcvjEv|_ZL20__hip_get_grid_dim_yv|llvm.nvvm.read.ptx.sreg.nctaid.y}} with constant i32 16
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI13__HIP_GridDimE3__ZcvjEv|_ZL20__hip_get_grid_dim_zv|llvm.nvvm.read.ptx.sreg.nctaid.z}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI14__HIP_BlockDimE3__XcvjEv|_ZL21__hip_get_block_dim_xv|llvm.nvvm.read.ptx.sreg.ntid.x}}  with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI14__HIP_BlockDimE3__YcvjEv|_ZL21__hip_get_block_dim_yv|llvm.nvvm.read.ptx.sreg.ntid.y}}  with constant i32 1024
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI14__HIP_BlockDimE3__ZcvjEv|_ZL21__hip_get_block_dim_zv|llvm.nvvm.read.ptx.sreg.ntid.z}}  with constant i32 1
 // CHECK-FIRST: [DimSpec]
 // CHECK-FIRST: [DimSpec]
 // CHECK-FIRST: [DimSpec]

--- a/tests/gpu/block_grid_dim_2d.cpp
+++ b/tests/gpu/block_grid_dim_2d.cpp
@@ -1,6 +1,6 @@
 // clang-format off
 // RUN: rm -rf .proteus
-// RUN: ./block_grid_dim_2d.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: PROTEUS_TRACE_OUTPUT=1 ./block_grid_dim_2d.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
 // RUN: ./block_grid_dim_2d.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
 // RUN: rm -rf .proteus
@@ -27,83 +27,88 @@ __global__ __attribute__((annotate("jit"))) void kernel() {
 int main() {
   proteus::init();
 
-  for (int Tid = 1; Tid <= 32; Tid++) {
-    dim3 BlockDim(1, Tid * 32, 1);
-    dim3 GridDim(1, Tid, 1);
+  for (int Tid = 64; Tid <= 1024; Tid *= 2) {
+    dim3 BlockDim(1, Tid, 1);
+    dim3 GridDim(1, Tid / 64, 1);
     kernel<<<GridDim, BlockDim>>>();
+    gpuErrCheck(gpuDeviceSynchronize());
   }
-  gpuErrCheck(gpuDeviceSynchronize());
 
   proteus::finalize();
   return 0;
 }
 
 // clang-format off
-// CHECK:ThreadId: (0 31 0) BlockID: (0 0 0) BlockDim: (1 32 1) GridDim: (1 1 1)
-// CHECK:ThreadId: (0 63 0) BlockID: (0 1 0) BlockDim: (1 64 1) GridDim: (1 2 1)
-// CHECK:ThreadId: (0 95 0) BlockID: (0 2 0) BlockDim: (1 96 1) GridDim: (1 3 1)
-// CHECK:ThreadId: (0 127 0) BlockID: (0 3 0) BlockDim: (1 128 1) GridDim: (1 4 1)
-// CHECK:ThreadId: (0 159 0) BlockID: (0 4 0) BlockDim: (1 160 1) GridDim: (1 5 1)
-// CHECK:ThreadId: (0 191 0) BlockID: (0 5 0) BlockDim: (1 192 1) GridDim: (1 6 1)
-// CHECK:ThreadId: (0 223 0) BlockID: (0 6 0) BlockDim: (1 224 1) GridDim: (1 7 1)
-// CHECK:ThreadId: (0 255 0) BlockID: (0 7 0) BlockDim: (1 256 1) GridDim: (1 8 1)
-// CHECK:ThreadId: (0 287 0) BlockID: (0 8 0) BlockDim: (1 288 1) GridDim: (1 9 1)
-// CHECK:ThreadId: (0 319 0) BlockID: (0 9 0) BlockDim: (1 320 1) GridDim: (1 10 1)
-// CHECK:ThreadId: (0 351 0) BlockID: (0 10 0) BlockDim: (1 352 1) GridDim: (1 11 1)
-// CHECK:ThreadId: (0 383 0) BlockID: (0 11 0) BlockDim: (1 384 1) GridDim: (1 12 1)
-// CHECK:ThreadId: (0 415 0) BlockID: (0 12 0) BlockDim: (1 416 1) GridDim: (1 13 1)
-// CHECK:ThreadId: (0 447 0) BlockID: (0 13 0) BlockDim: (1 448 1) GridDim: (1 14 1)
-// CHECK:ThreadId: (0 479 0) BlockID: (0 14 0) BlockDim: (1 480 1) GridDim: (1 15 1)
-// CHECK:ThreadId: (0 511 0) BlockID: (0 15 0) BlockDim: (1 512 1) GridDim: (1 16 1)
-// CHECK:ThreadId: (0 543 0) BlockID: (0 16 0) BlockDim: (1 544 1) GridDim: (1 17 1)
-// CHECK:ThreadId: (0 575 0) BlockID: (0 17 0) BlockDim: (1 576 1) GridDim: (1 18 1)
-// CHECK:ThreadId: (0 607 0) BlockID: (0 18 0) BlockDim: (1 608 1) GridDim: (1 19 1)
-// CHECK:ThreadId: (0 639 0) BlockID: (0 19 0) BlockDim: (1 640 1) GridDim: (1 20 1)
-// CHECK:ThreadId: (0 671 0) BlockID: (0 20 0) BlockDim: (1 672 1) GridDim: (1 21 1)
-// CHECK:ThreadId: (0 703 0) BlockID: (0 21 0) BlockDim: (1 704 1) GridDim: (1 22 1)
-// CHECK:ThreadId: (0 735 0) BlockID: (0 22 0) BlockDim: (1 736 1) GridDim: (1 23 1)
-// CHECK:ThreadId: (0 767 0) BlockID: (0 23 0) BlockDim: (1 768 1) GridDim: (1 24 1)
-// CHECK:ThreadId: (0 799 0) BlockID: (0 24 0) BlockDim: (1 800 1) GridDim: (1 25 1)
-// CHECK:ThreadId: (0 831 0) BlockID: (0 25 0) BlockDim: (1 832 1) GridDim: (1 26 1)
-// CHECK:ThreadId: (0 863 0) BlockID: (0 26 0) BlockDim: (1 864 1) GridDim: (1 27 1)
-// CHECK:ThreadId: (0 895 0) BlockID: (0 27 0) BlockDim: (1 896 1) GridDim: (1 28 1)
-// CHECK:ThreadId: (0 927 0) BlockID: (0 28 0) BlockDim: (1 928 1) GridDim: (1 29 1)
-// CHECK:ThreadId: (0 959 0) BlockID: (0 29 0) BlockDim: (1 960 1) GridDim: (1 30 1)
-// CHECK:ThreadId: (0 991 0) BlockID: (0 30 0) BlockDim: (1 992 1) GridDim: (1 31 1)
-// CHECK:ThreadId: (0 1023 0) BlockID: (0 31 0) BlockDim: (1 1024 1) GridDim: (1 32 1)
-
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-// CHECK-FIRST: JitStorageCache hits 0 total 32
-// CHECK-SECOND: JitStorageCache hits 32 total 32
-// clang-format on
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_xv|llvm.nvvm.read.ptx.sreg.nctaid.x}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_yv|llvm.nvvm.read.ptx.sreg.nctaid.y}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_zv|llvm.nvvm.read.ptx.sreg.nctaid.z}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_xv|llvm.nvvm.read.ptx.sreg.ntid.x}}  with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_yv|llvm.nvvm.read.ptx.sreg.ntid.y}}  with constant i32 64
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_zv|llvm.nvvm.read.ptx.sreg.ntid.z}}  with constant i32 1
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [LaunchBoundSpec] GridSize 1 BlockSize 64
+// CHECK: ThreadId: (0 63 0) BlockID: (0 0 0) BlockDim: (1 64 1) GridDim: (1 1 1)
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_xv|llvm.nvvm.read.ptx.sreg.nctaid.x}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_yv|llvm.nvvm.read.ptx.sreg.nctaid.y}} with constant i32 2
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_zv|llvm.nvvm.read.ptx.sreg.nctaid.z}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_xv|llvm.nvvm.read.ptx.sreg.ntid.x}}  with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_yv|llvm.nvvm.read.ptx.sreg.ntid.y}}  with constant i32 128
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_zv|llvm.nvvm.read.ptx.sreg.ntid.z}}  with constant i32 1
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [LaunchBoundSpec] GridSize 2 BlockSize 128
+// CHECK: ThreadId: (0 127 0) BlockID: (0 1 0) BlockDim: (1 128 1) GridDim: (1 2 1)
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_xv|llvm.nvvm.read.ptx.sreg.nctaid.x}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_yv|llvm.nvvm.read.ptx.sreg.nctaid.y}} with constant i32 4
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_zv|llvm.nvvm.read.ptx.sreg.nctaid.z}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_xv|llvm.nvvm.read.ptx.sreg.ntid.x}}  with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_yv|llvm.nvvm.read.ptx.sreg.ntid.y}}  with constant i32 256
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_zv|llvm.nvvm.read.ptx.sreg.ntid.z}}  with constant i32 1
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [LaunchBoundSpec] GridSize 4 BlockSize 256
+// CHECK: ThreadId: (0 255 0) BlockID: (0 3 0) BlockDim: (1 256 1) GridDim: (1 4 1)
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_xv|llvm.nvvm.read.ptx.sreg.nctaid.x}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_yv|llvm.nvvm.read.ptx.sreg.nctaid.y}} with constant i32 8
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_zv|llvm.nvvm.read.ptx.sreg.nctaid.z}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_xv|llvm.nvvm.read.ptx.sreg.ntid.x}}  with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_yv|llvm.nvvm.read.ptx.sreg.ntid.y}}  with constant i32 512
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_zv|llvm.nvvm.read.ptx.sreg.ntid.z}}  with constant i32 1
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [LaunchBoundSpec] GridSize 8 BlockSize 512
+// CHECK: ThreadId: (0 511 0) BlockID: (0 7 0) BlockDim: (1 512 1) GridDim: (1 8 1)
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_xv|llvm.nvvm.read.ptx.sreg.nctaid.x}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_yv|llvm.nvvm.read.ptx.sreg.nctaid.y}} with constant i32 16
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_zv|llvm.nvvm.read.ptx.sreg.nctaid.z}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_xv|llvm.nvvm.read.ptx.sreg.ntid.x}}  with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_yv|llvm.nvvm.read.ptx.sreg.ntid.y}}  with constant i32 1024
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_zv|llvm.nvvm.read.ptx.sreg.ntid.z}}  with constant i32 1
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [LaunchBoundSpec] GridSize 16 BlockSize 1024
+// CHECK: ThreadId: (0 1023 0) BlockID: (0 15 0) BlockDim: (1 1024 1) GridDim: (1 16 1)
+// CHECK-COUNT-5: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
+// CHECK-FIRST: JitStorageCache hits 0 total 5
+// CHECK-SECOND: JitStorageCache hits 5 total 5

--- a/tests/gpu/block_grid_dim_3d.cpp
+++ b/tests/gpu/block_grid_dim_3d.cpp
@@ -1,6 +1,6 @@
 // clang-format off
 // RUN: rm -rf .proteus
-// RUN: ./block_grid_dim_3d.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: PROTEUS_TRACE_OUTPUT=1 ./block_grid_dim_3d.%ext |  %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
 // RUN:./block_grid_dim_3d.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
 // RUN: rm -rf .proteus
@@ -27,9 +27,11 @@ __global__ __attribute__((annotate("jit"))) void kernel() {
 int main() {
   proteus::init();
 
-  for (int Tid = 1; Tid <= 2; Tid++) {
-    dim3 BlockDim(1, 1, Tid * 32);
-    dim3 GridDim(1, 1, Tid);
+  // Maximum BlockSize in the z-dimension is 64 for CUDA, hence the reduced
+  // iteration space.
+  for (int Tid = 4; Tid <= 64; Tid *= 2) {
+    dim3 BlockDim(1, 1, Tid);
+    dim3 GridDim(1, 1, Tid / 4);
     kernel<<<GridDim, BlockDim>>>();
     gpuErrCheck(gpuDeviceSynchronize());
   }
@@ -39,11 +41,76 @@ int main() {
 }
 
 // clang-format off
-// CHECK:ThreadId: (0 0 31) BlockID: (0 0 0) BlockDim: (1 1 32) GridDim: (1 1 1)
-// CHECK:ThreadId: (0 0 63) BlockID: (0 0 1) BlockDim: (1 1 64) GridDim: (1 1 2)
-
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-//CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-// CHECK-FIRST: JitStorageCache hits 0 total 2
-// CHECK-SECOND: JitStorageCache hits 2 total 2
-// clang-format on
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_xv|llvm.nvvm.read.ptx.sreg.nctaid.x}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_yv|llvm.nvvm.read.ptx.sreg.nctaid.y}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_zv|llvm.nvvm.read.ptx.sreg.nctaid.z}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_xv|llvm.nvvm.read.ptx.sreg.ntid.x}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_yv|llvm.nvvm.read.ptx.sreg.ntid.y}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_zv|llvm.nvvm.read.ptx.sreg.ntid.z}} with constant i32 4
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [LaunchBoundSpec] GridSize 1 BlockSize 4
+// CHECK: ThreadId: (0 0 3) BlockID: (0 0 0) BlockDim: (1 1 4) GridDim: (1 1 1)
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_xv|llvm.nvvm.read.ptx.sreg.nctaid.x}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_yv|llvm.nvvm.read.ptx.sreg.nctaid.y}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_zv|llvm.nvvm.read.ptx.sreg.nctaid.z}} with constant i32 2
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_xv|llvm.nvvm.read.ptx.sreg.ntid.x}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_yv|llvm.nvvm.read.ptx.sreg.ntid.y}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_zv|llvm.nvvm.read.ptx.sreg.ntid.z}} with constant i32 8
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [LaunchBoundSpec] GridSize 2 BlockSize 8
+// CHECK: ThreadId: (0 0 7) BlockID: (0 0 1) BlockDim: (1 1 8) GridDim: (1 1 2)
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_xv|llvm.nvvm.read.ptx.sreg.nctaid.x}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_yv|llvm.nvvm.read.ptx.sreg.nctaid.y}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_zv|llvm.nvvm.read.ptx.sreg.nctaid.z}} with constant i32 4
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_xv|llvm.nvvm.read.ptx.sreg.ntid.x}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_yv|llvm.nvvm.read.ptx.sreg.ntid.y}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_zv|llvm.nvvm.read.ptx.sreg.ntid.z}} with constant i32 16
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [LaunchBoundSpec] GridSize 4 BlockSize 16
+// CHECK: ThreadId: (0 0 15) BlockID: (0 0 3) BlockDim: (1 1 16) GridDim: (1 1 4)
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_xv|llvm.nvvm.read.ptx.sreg.nctaid.x}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_yv|llvm.nvvm.read.ptx.sreg.nctaid.y}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_zv|llvm.nvvm.read.ptx.sreg.nctaid.z}} with constant i32 8
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_xv|llvm.nvvm.read.ptx.sreg.ntid.x}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_yv|llvm.nvvm.read.ptx.sreg.ntid.y}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_zv|llvm.nvvm.read.ptx.sreg.ntid.z}} with constant i32 32
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [LaunchBoundSpec] GridSize 8 BlockSize 32
+// CHECK: ThreadId: (0 0 31) BlockID: (0 0 7) BlockDim: (1 1 32) GridDim: (1 1 8)
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_xv|llvm.nvvm.read.ptx.sreg.nctaid.x}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_yv|llvm.nvvm.read.ptx.sreg.nctaid.y}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_zv|llvm.nvvm.read.ptx.sreg.nctaid.z}} with constant i32 16
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_xv|llvm.nvvm.read.ptx.sreg.ntid.x}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_yv|llvm.nvvm.read.ptx.sreg.ntid.y}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_zv|llvm.nvvm.read.ptx.sreg.ntid.z}} with constant i32 64
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [LaunchBoundSpec] GridSize 16 BlockSize 64
+// CHECK: ThreadId: (0 0 63) BlockID: (0 0 15) BlockDim: (1 1 64) GridDim: (1 1 16)
+// CHECK-COUNT-5: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
+// CHECK-FIRST: JitStorageCache hits 0 total 5
+// CHECK-SECOND: JitStorageCache hits 5 total 5

--- a/tests/gpu/block_grid_dim_3d.cpp
+++ b/tests/gpu/block_grid_dim_3d.cpp
@@ -2,7 +2,7 @@
 // RUN: rm -rf .proteus
 // RUN: PROTEUS_TRACE_OUTPUT=1 ./block_grid_dim_3d.%ext |  %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN:./block_grid_dim_3d.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: ./block_grid_dim_3d.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
 // RUN: rm -rf .proteus
 // clang-format on
 
@@ -41,12 +41,12 @@ int main() {
 }
 
 // clang-format off
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_xv|llvm.nvvm.read.ptx.sreg.nctaid.x}} with constant i32 1
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_yv|llvm.nvvm.read.ptx.sreg.nctaid.y}} with constant i32 1
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_zv|llvm.nvvm.read.ptx.sreg.nctaid.z}} with constant i32 1
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_xv|llvm.nvvm.read.ptx.sreg.ntid.x}} with constant i32 1
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_yv|llvm.nvvm.read.ptx.sreg.ntid.y}} with constant i32 1
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_zv|llvm.nvvm.read.ptx.sreg.ntid.z}} with constant i32 4
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI13__HIP_GridDimE3__XcvjEv|_ZL20__hip_get_grid_dim_xv|llvm.nvvm.read.ptx.sreg.nctaid.x}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI13__HIP_GridDimE3__YcvjEv|_ZL20__hip_get_grid_dim_yv|llvm.nvvm.read.ptx.sreg.nctaid.y}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI13__HIP_GridDimE3__ZcvjEv|_ZL20__hip_get_grid_dim_zv|llvm.nvvm.read.ptx.sreg.nctaid.z}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI14__HIP_BlockDimE3__XcvjEv|_ZL21__hip_get_block_dim_xv|llvm.nvvm.read.ptx.sreg.ntid.x}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI14__HIP_BlockDimE3__YcvjEv|_ZL21__hip_get_block_dim_yv|llvm.nvvm.read.ptx.sreg.ntid.y}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI14__HIP_BlockDimE3__ZcvjEv|_ZL21__hip_get_block_dim_zv|llvm.nvvm.read.ptx.sreg.ntid.z}} with constant i32 4
 // CHECK-FIRST: [DimSpec]
 // CHECK-FIRST: [DimSpec]
 // CHECK-FIRST: [DimSpec]
@@ -55,12 +55,12 @@ int main() {
 // CHECK-FIRST: [DimSpec]
 // CHECK-FIRST: [LaunchBoundSpec] GridSize 1 BlockSize 4
 // CHECK: ThreadId: (0 0 3) BlockID: (0 0 0) BlockDim: (1 1 4) GridDim: (1 1 1)
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_xv|llvm.nvvm.read.ptx.sreg.nctaid.x}} with constant i32 1
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_yv|llvm.nvvm.read.ptx.sreg.nctaid.y}} with constant i32 1
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_zv|llvm.nvvm.read.ptx.sreg.nctaid.z}} with constant i32 2
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_xv|llvm.nvvm.read.ptx.sreg.ntid.x}} with constant i32 1
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_yv|llvm.nvvm.read.ptx.sreg.ntid.y}} with constant i32 1
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_zv|llvm.nvvm.read.ptx.sreg.ntid.z}} with constant i32 8
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI13__HIP_GridDimE3__XcvjEv|_ZL20__hip_get_grid_dim_xv|llvm.nvvm.read.ptx.sreg.nctaid.x}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI13__HIP_GridDimE3__YcvjEv|_ZL20__hip_get_grid_dim_yv|llvm.nvvm.read.ptx.sreg.nctaid.y}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI13__HIP_GridDimE3__ZcvjEv|_ZL20__hip_get_grid_dim_zv|llvm.nvvm.read.ptx.sreg.nctaid.z}} with constant i32 2
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI14__HIP_BlockDimE3__XcvjEv|_ZL21__hip_get_block_dim_xv|llvm.nvvm.read.ptx.sreg.ntid.x}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI14__HIP_BlockDimE3__YcvjEv|_ZL21__hip_get_block_dim_yv|llvm.nvvm.read.ptx.sreg.ntid.y}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI14__HIP_BlockDimE3__ZcvjEv|_ZL21__hip_get_block_dim_zv|llvm.nvvm.read.ptx.sreg.ntid.z}} with constant i32 8
 // CHECK-FIRST: [DimSpec]
 // CHECK-FIRST: [DimSpec]
 // CHECK-FIRST: [DimSpec]
@@ -69,12 +69,12 @@ int main() {
 // CHECK-FIRST: [DimSpec]
 // CHECK-FIRST: [LaunchBoundSpec] GridSize 2 BlockSize 8
 // CHECK: ThreadId: (0 0 7) BlockID: (0 0 1) BlockDim: (1 1 8) GridDim: (1 1 2)
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_xv|llvm.nvvm.read.ptx.sreg.nctaid.x}} with constant i32 1
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_yv|llvm.nvvm.read.ptx.sreg.nctaid.y}} with constant i32 1
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_zv|llvm.nvvm.read.ptx.sreg.nctaid.z}} with constant i32 4
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_xv|llvm.nvvm.read.ptx.sreg.ntid.x}} with constant i32 1
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_yv|llvm.nvvm.read.ptx.sreg.ntid.y}} with constant i32 1
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_zv|llvm.nvvm.read.ptx.sreg.ntid.z}} with constant i32 16
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI13__HIP_GridDimE3__XcvjEv|_ZL20__hip_get_grid_dim_xv|llvm.nvvm.read.ptx.sreg.nctaid.x}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI13__HIP_GridDimE3__YcvjEv|_ZL20__hip_get_grid_dim_yv|llvm.nvvm.read.ptx.sreg.nctaid.y}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI13__HIP_GridDimE3__ZcvjEv|_ZL20__hip_get_grid_dim_zv|llvm.nvvm.read.ptx.sreg.nctaid.z}} with constant i32 4
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI14__HIP_BlockDimE3__XcvjEv|_ZL21__hip_get_block_dim_xv|llvm.nvvm.read.ptx.sreg.ntid.x}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI14__HIP_BlockDimE3__YcvjEv|_ZL21__hip_get_block_dim_yv|llvm.nvvm.read.ptx.sreg.ntid.y}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI14__HIP_BlockDimE3__ZcvjEv|_ZL21__hip_get_block_dim_zv|llvm.nvvm.read.ptx.sreg.ntid.z}} with constant i32 16
 // CHECK-FIRST: [DimSpec]
 // CHECK-FIRST: [DimSpec]
 // CHECK-FIRST: [DimSpec]
@@ -83,12 +83,12 @@ int main() {
 // CHECK-FIRST: [DimSpec]
 // CHECK-FIRST: [LaunchBoundSpec] GridSize 4 BlockSize 16
 // CHECK: ThreadId: (0 0 15) BlockID: (0 0 3) BlockDim: (1 1 16) GridDim: (1 1 4)
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_xv|llvm.nvvm.read.ptx.sreg.nctaid.x}} with constant i32 1
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_yv|llvm.nvvm.read.ptx.sreg.nctaid.y}} with constant i32 1
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_zv|llvm.nvvm.read.ptx.sreg.nctaid.z}} with constant i32 8
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_xv|llvm.nvvm.read.ptx.sreg.ntid.x}} with constant i32 1
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_yv|llvm.nvvm.read.ptx.sreg.ntid.y}} with constant i32 1
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_zv|llvm.nvvm.read.ptx.sreg.ntid.z}} with constant i32 32
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI13__HIP_GridDimE3__XcvjEv|_ZL20__hip_get_grid_dim_xv|llvm.nvvm.read.ptx.sreg.nctaid.x}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI13__HIP_GridDimE3__YcvjEv|_ZL20__hip_get_grid_dim_yv|llvm.nvvm.read.ptx.sreg.nctaid.y}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI13__HIP_GridDimE3__ZcvjEv|_ZL20__hip_get_grid_dim_zv|llvm.nvvm.read.ptx.sreg.nctaid.z}} with constant i32 8
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI14__HIP_BlockDimE3__XcvjEv|_ZL21__hip_get_block_dim_xv|llvm.nvvm.read.ptx.sreg.ntid.x}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI14__HIP_BlockDimE3__YcvjEv|_ZL21__hip_get_block_dim_yv|llvm.nvvm.read.ptx.sreg.ntid.y}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI14__HIP_BlockDimE3__ZcvjEv|_ZL21__hip_get_block_dim_zv|llvm.nvvm.read.ptx.sreg.ntid.z}} with constant i32 32
 // CHECK-FIRST: [DimSpec]
 // CHECK-FIRST: [DimSpec]
 // CHECK-FIRST: [DimSpec]
@@ -97,12 +97,12 @@ int main() {
 // CHECK-FIRST: [DimSpec]
 // CHECK-FIRST: [LaunchBoundSpec] GridSize 8 BlockSize 32
 // CHECK: ThreadId: (0 0 31) BlockID: (0 0 7) BlockDim: (1 1 32) GridDim: (1 1 8)
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_xv|llvm.nvvm.read.ptx.sreg.nctaid.x}} with constant i32 1
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_yv|llvm.nvvm.read.ptx.sreg.nctaid.y}} with constant i32 1
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL20__hip_get_grid_dim_zv|llvm.nvvm.read.ptx.sreg.nctaid.z}} with constant i32 16
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_xv|llvm.nvvm.read.ptx.sreg.ntid.x}} with constant i32 1
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_yv|llvm.nvvm.read.ptx.sreg.ntid.y}} with constant i32 1
-// CHECK-FIRST: [DimSpec] Replace call to {{_ZL21__hip_get_block_dim_zv|llvm.nvvm.read.ptx.sreg.ntid.z}} with constant i32 64
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI13__HIP_GridDimE3__XcvjEv|_ZL20__hip_get_grid_dim_xv|llvm.nvvm.read.ptx.sreg.nctaid.x}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI13__HIP_GridDimE3__YcvjEv|_ZL20__hip_get_grid_dim_yv|llvm.nvvm.read.ptx.sreg.nctaid.y}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI13__HIP_GridDimE3__ZcvjEv|_ZL20__hip_get_grid_dim_zv|llvm.nvvm.read.ptx.sreg.nctaid.z}} with constant i32 16
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI14__HIP_BlockDimE3__XcvjEv|_ZL21__hip_get_block_dim_xv|llvm.nvvm.read.ptx.sreg.ntid.x}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI14__HIP_BlockDimE3__YcvjEv|_ZL21__hip_get_block_dim_yv|llvm.nvvm.read.ptx.sreg.ntid.y}} with constant i32 1
+// CHECK-FIRST: [DimSpec] Replace call to {{_ZNK17__HIP_CoordinatesI14__HIP_BlockDimE3__ZcvjEv|_ZL21__hip_get_block_dim_zv|llvm.nvvm.read.ptx.sreg.ntid.z}} with constant i32 64
 // CHECK-FIRST: [DimSpec]
 // CHECK-FIRST: [DimSpec]
 // CHECK-FIRST: [DimSpec]

--- a/tests/gpu/builtin_globals.cpp
+++ b/tests/gpu/builtin_globals.cpp
@@ -1,6 +1,6 @@
 // clang-format off
 // RUN: rm -rf .proteus
-// RUN: ./builtin_globals.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: PROTEUS_TRACE_OUTPUT=1 ./builtin_globals.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
 // RUN: ./builtin_globals.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
 // RUN: rm -rf .proteus
@@ -30,6 +30,14 @@ int main() {
   return 0;
 }
 
+// clang-format off
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [LaunchBoundSpec] GridSize 1 BlockSize 1
 // CHECK: Kernel
 // CHECK: JitCache hits 0 total 1
 // CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0

--- a/tests/gpu/daxpy.cpp
+++ b/tests/gpu/daxpy.cpp
@@ -1,8 +1,9 @@
+// clang-format off
 // RUN: rm -rf .proteus
-// RUN: ./daxpy.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
-// Second run uses the object cache.
-// RUN: ./daxpy.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: PROTEUS_TRACE_OUTPUT=1 ./daxpy.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// ./daxpy.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
 // RUN: rm -rf .proteus
+// clang-format on
 
 #include <cstddef>
 #include <cstdlib>
@@ -62,7 +63,11 @@ int main() {
   proteus::finalize();
 }
 
+// clang-format off
 // CHECK: 0
+// CHECK-FIRST: [ArgSpec] Replaced Function _Z9daxpyImpldPdS_m ArgNo 3 with value i64 1024
+// CHECK-FIRST: [DimSpec]
+// CHECK-FIRST: [DimSpec]
 // CHECK: 19944.1
 // CHECK: 39888.2
 // CHECK: JitCache hits 1 total 2

--- a/tests/gpu/indirect_launcher_arg.cpp
+++ b/tests/gpu/indirect_launcher_arg.cpp
@@ -1,6 +1,6 @@
 // clang-format off
 // RUN: rm -rf .proteus
-// RUN: ./indirect_launcher_arg.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: PROTEUS_TRACE_OUTPUT=1 ./indirect_launcher_arg.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
 // RUN: ./indirect_launcher_arg.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
 // RUN: rm -rf .proteus
@@ -25,6 +25,7 @@ int main() {
   proteus::init();
 
   kernel<<<1, 1>>>(42);
+  gpuErrCheck(gpuDeviceSynchronize());
   gpuErrCheck(launcher(kernel, 24));
   gpuErrCheck(gpuDeviceSynchronize());
 
@@ -32,7 +33,12 @@ int main() {
   return 0;
 }
 
+// clang-format off
+// CHECK-FIRST: [ArgSpec] Replaced Function _Z6kerneli ArgNo 0 with value i32 42
+// CHECK-FIRST: [LaunchBoundSpec] GridSize 1 BlockSize 1
 // CHECK: Kernel 42
+// CHECK-FIRST: [ArgSpec] Replaced Function _Z6kerneli ArgNo 0 with value i32 24
+// CHECK-FIRST: [LaunchBoundSpec] GridSize 1 BlockSize 1
 // CHECK: Kernel 24
 // CHECK: JitCache hits 0 total 2
 // CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0

--- a/tests/gpu/indirect_launcher_tpl_multi_arg.cpp
+++ b/tests/gpu/indirect_launcher_tpl_multi_arg.cpp
@@ -1,6 +1,6 @@
 // clang-format off
 // RUN: rm -rf .proteus
-// RUN: ./indirect_launcher_tpl_multi_arg.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: PROTEUS_TRACE_OUTPUT=1 ./indirect_launcher_tpl_multi_arg.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
 // RUN: ./indirect_launcher_tpl_multi_arg.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
 // RUN: rm -rf .proteus
@@ -30,6 +30,7 @@ int main() {
   proteus::init();
 
   gpuErrCheck(launcher(kernel, 42));
+  gpuErrCheck(gpuDeviceSynchronize());
   gpuErrCheck(launcher(kernelTwo, 24));
   gpuErrCheck(gpuDeviceSynchronize());
 
@@ -37,7 +38,12 @@ int main() {
   return 0;
 }
 
+// clang-format off
+// CHECK-FIRST: [ArgSpec] Replaced Function _Z6kerneli ArgNo 0 with value i32 42
+// CHECK-FIRST: [LaunchBoundSpec] GridSize 1 BlockSize 1
 // CHECK: Kernel one; arg = 42
+// CHECK-FIRST: [ArgSpec] Replaced Function _Z9kernelTwoi ArgNo 0 with value i32 24
+// CHECK-FIRST: [LaunchBoundSpec] GridSize 1 BlockSize 1
 // CHECK: Kernel two; arg = 24
 // CHECK: JitCache hits 0 total 2
 // CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0

--- a/tests/gpu/kernel.cpp
+++ b/tests/gpu/kernel.cpp
@@ -1,8 +1,10 @@
+// clang-format off
 // RUN: rm -rf .proteus
 // RUN: ./kernel.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
 // RUN: ./kernel.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
 // RUN: rm -rf .proteus
+// clang-format on
 #include <climits>
 #include <cstdio>
 

--- a/tests/gpu/kernel_args.cpp
+++ b/tests/gpu/kernel_args.cpp
@@ -1,8 +1,10 @@
+// clang-format off
 // RUN: rm -rf .proteus
-// RUN: ./kernel_args.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: PROTEUS_TRACE_OUTPUT=1 ./kernel_args.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
 // RUN: ./kernel_args.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
 // RUN: rm -rf .proteus
+// clang-format on
 #include <climits>
 #include <cstdio>
 
@@ -23,7 +25,11 @@ int main() {
   proteus::finalize();
   return 0;
 }
-
+// clang-format off
+// CHECK-FIRST: [ArgSpec] Replaced Function _Z6kerneliii ArgNo 0 with value i32 3
+// CHECK-FIRST: [ArgSpec] Replaced Function _Z6kerneliii ArgNo 1 with value i32 2
+// CHECK-FIRST: [ArgSpec] Replaced Function _Z6kerneliii ArgNo 2 with value i32 1
+// CHECK-FIRST: [LaunchBoundSpec] GridSize 1 BlockSize 1
 // CHECK: Kernel arg 6
 // CHECK: JitCache hits 0 total 1
 // CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0

--- a/tests/gpu/kernel_calls_func_lib.cpp
+++ b/tests/gpu/kernel_calls_func_lib.cpp
@@ -1,6 +1,6 @@
 // clang-format off
 // RUN: rm -rf .proteus
-// RUN: ./kernel_calls_func_lib.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: PROTEUS_TRACE_OUTPUT=1 ./kernel_calls_func_lib.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
 // RUN: ./kernel_calls_func_lib.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
 // RUN: rm -rf .proteus
@@ -28,6 +28,9 @@ int main() {
   return 0;
 }
 
+// clang-format off
+// CHECK-FIRST: [ArgSpec] Replaced Function _Z14kernelFunctioni ArgNo 0 with value i32 1
+// CHECK-FIRST: [LaunchBoundSpec] GridSize 1 BlockSize 1
 // CHECK: device_func 1
 // CHECK: Kernel with lib 1
 // CHECK: JitCache hits 0 total 1

--- a/tests/gpu/kernel_preset_bounds.cpp
+++ b/tests/gpu/kernel_preset_bounds.cpp
@@ -1,6 +1,6 @@
 // clang-format off
 // RUN: rm -rf .proteus
-// RUN: ./kernel_preset_bounds.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: PROTEUS_TRACE_OUTPUT=1 ./kernel_preset_bounds.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
 // RUN: ./kernel_preset_bounds.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
 // RUN: rm -rf .proteus
@@ -26,6 +26,7 @@ int main() {
   return 0;
 }
 
+// clang-format off
 // CHECK: Kernel
 // CHECK: JitCache hits 0 total 1
 // CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0

--- a/tests/gpu/kernel_repeat.cpp
+++ b/tests/gpu/kernel_repeat.cpp
@@ -1,8 +1,10 @@
+// clang-format off
 // RUN: rm -rf .proteus
-// RUN: ./kernel_repeat.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: PROTEUS_TRACE_OUTPUT=1 ./kernel_repeat.%ext |  %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
 // RUN: ./kernel_repeat.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
 // RUN: rm -rf .proteus
+// clang-format on
 #include <climits>
 #include <cstdio>
 
@@ -24,6 +26,9 @@ int main() {
   return 0;
 }
 
+// clang-format off
+// CHECK-FIRST: [ArgSpec] Replaced Function _Z6kerneli ArgNo 0 with value i32 42
+// CHECK-FIRST: [LaunchBoundSpec] GridSize 1 BlockSize 1
 // CHECK-COUNT-1000: Kernel i 42
 // CHECK: JitCache hits 999 total 1000
 // CHECK: HashValue {{[0-9]+}} NumExecs 1000 NumHits 999

--- a/tests/gpu/kernel_unused_gvar.cpp
+++ b/tests/gpu/kernel_unused_gvar.cpp
@@ -29,6 +29,7 @@ int main() {
   return 0;
 }
 
+// clang-format off
 // CHECK: Kernel
 // CHECK: Kernel gvar
 // CHECK: JitCache hits 0 total 2

--- a/tests/gpu/lambda_def.cpp
+++ b/tests/gpu/lambda_def.cpp
@@ -1,6 +1,6 @@
 // clang-format off
 // RUN: rm -rf .proteus
-// RUN: ./lambda_def.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: PROTEUS_TRACE_OUTPUT=1 ./lambda_def.%ext |  %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
 // RUN: ./lambda_def.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
 // RUN: rm -rf .proteus
@@ -26,10 +26,9 @@ int main() {
   proteus::init();
 
   int A = 42;
-  auto Lambda = [ =, A = proteus::jit_variable(A) ] __device__()
-      __attribute__((annotate("jit"))) {
-    printf("Lambda A %d\n", A);
-  };
+  auto Lambda =
+      [=, A = proteus::jit_variable(A)] __device__()
+          __attribute__((annotate("jit"))) { printf("Lambda A %d\n", A); };
   run(Lambda);
   run(Lambda);
   run(Lambda);
@@ -38,7 +37,9 @@ int main() {
   return 0;
 }
 
-// CHECK-3: Lambda 42
+// clang-format off
+// CHECK-FIRST: [LambdaSpec] Replacing slot 0 with i32 42
+// CHECK-COUNT-3: Lambda A 42
 // CHECK: JitCache hits 2 total 3
 // CHECK: HashValue {{[0-9]+}} NumExecs 3 NumHits 2
 // CHECK-FIRST: JitStorageCache hits 0 total 1

--- a/tests/gpu/lambda_host_device.cpp
+++ b/tests/gpu/lambda_host_device.cpp
@@ -1,6 +1,6 @@
 // clang-format off
 // RUN: rm -rf .proteus
-// RUN: ./lambda_host_device.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: PROTEUS_TRACE_OUTPUT=1 ./lambda_host_device.%ext |  %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
 // RUN: ./lambda_host_device.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
 // RUN: rm -rf .proteus
@@ -26,14 +26,19 @@ template <typename T> void launcher(T &&LB) {
 int main() {
   proteus::init();
   int A = 42;
-  launcher([ =, A = proteus::jit_variable(A) ] __host__ __device__()
+  launcher([=, A = proteus::jit_variable(A)] __host__ __device__()
                __attribute__((annotate("jit"))) { printf("Lambda %d\n", A); });
   proteus::finalize();
 }
 
+// clang-format off
+// CHECK-FIRST: [LambdaSpec] Replacing slot 0 with i32 42
 // CHECK: Lambda 42
+// CHECK-FIRST: [LambdaSpec] Replacing slot 0 with i32 42
 // CHECK: Lambda 42
-// CHECK-2: JitCache hits 0 total 1
-// CHECK-2: HashValue {{[0-9]+}} NumExecs 2 NumHits 1
+// CHECK: JitCache hits 0 total 1
+// CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
+// CHECK: JitCache hits 0 total 1
+// CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
 // CHECK-FIRST: JitStorageCache hits 0 total 1
 // CHECK-SECOND: JitStorageCache hits 1 total 1

--- a/tests/gpu/lambda_multiple.cpp
+++ b/tests/gpu/lambda_multiple.cpp
@@ -1,6 +1,6 @@
 // clang-format off
 // RUN: rm -rf .proteus
-// RUN: ./lambda_multiple.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: PROTEUS_TRACE_OUTPUT=1 ./lambda_multiple.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
 // RUN: ./lambda_multiple.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
 // RUN: rm -rf .proteus
@@ -49,13 +49,16 @@ int main() {
   proteus::finalize();
 }
 
+// clang-format off
+// CHECK-FIRST: [LambdaSpec] Replacing slot 0 with i32 1
 // CHECK: V 1
 // CHECK: Kernel simple
+// CHECK-FIRST: [LambdaSpec] Replacing slot 0 with i32 2
 // CHECK: V 2
 // CHECK: V 1
 // CHECK: Kernel simple
 // CHECK: V 2
 // CHECK: JitCache hits 3 total 6
-// CHECK-3: HashValue {{[0-9]+}} NumExecs 2 NumHits 1
+// CHECK-COUNT-3: HashValue {{[0-9]+}} NumExecs 2 NumHits 1
 // CHECK-FIRST: JitStorageCache hits 0 total 3
 // CHECK-SECOND: JitStorageCache hits 3 total 3

--- a/tests/gpu/shared_array.cpp
+++ b/tests/gpu/shared_array.cpp
@@ -42,7 +42,7 @@ int main() {
 
 // clang-format off
 // CHECK-FIRST: [LambdaSpec] Replacing slot 0 with i32 3
-// CHECK-FIRST: [SharedArray] Replace CB   %{{[0-9]+}} = call {{.*}} ptr @_ZN7proteus12shared_arrayIdEEPT_mm(i64 noundef %{{[0-9]+}}, i64 noundef 8) #{{[0-9]+}} with @.proteus.shared = internal addrspace(3) global [24 x i8] undef, align 16
+// CHECK-FIRST: [SharedArray] Replace CB double* proteus::shared_array<double>(unsigned long, unsigned long) with @.proteus.shared = internal addrspace(3) global [24 x i8] undef, align 16
 // CHECK-FIRST: [LaunchBoundSpec] GridSize 1 BlockSize 1
 // CHECK: Kernel
 // CHECK: Lambda Array[0] 1.000000 Array[1] 2.000000 Array[2] 3.000000

--- a/tests/gpu/shared_array.cpp
+++ b/tests/gpu/shared_array.cpp
@@ -1,8 +1,10 @@
+// clang-format off
 // RUN: rm -rf .proteus
-// RUN: ./shared_array.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: PROTEUS_TRACE_OUTPUT=1 ./shared_array.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
 // RUN: ./shared_array.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
 // RUN: rm -rf .proteus
+// clang-format on
 #include <climits>
 #include <cstdio>
 
@@ -38,6 +40,10 @@ int main() {
   return 0;
 }
 
+// clang-format off
+// CHECK-FIRST: [LambdaSpec] Replacing slot 0 with i32 3
+// CHECK-FIRST: [SharedArray] Replace CB   %{{[0-9]+}} = call {{.*}} ptr @_ZN7proteus12shared_arrayIdEEPT_mm(i64 noundef %{{[0-9]+}}, i64 noundef 8) #{{[0-9]+}} with @.proteus.shared = internal addrspace(3) global [24 x i8] undef, align 16
+// CHECK-FIRST: [LaunchBoundSpec] GridSize 1 BlockSize 1
 // CHECK: Kernel
 // CHECK: Lambda Array[0] 1.000000 Array[1] 2.000000 Array[2] 3.000000
 // CHECK: JitCache hits 0 total 1

--- a/tests/gpu/types.cpp
+++ b/tests/gpu/types.cpp
@@ -1,6 +1,10 @@
+// clang-format off
 // RUN: rm -rf .proteus
-// RUN: ./types.%ext | %FILECHECK %s --check-prefixes=CHECK
+// RUN: PROTEUS_TRACE_OUTPUT=1 ./types.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// Second run uses the object cache.
+// RUN: ./types.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
 // RUN: rm -rf .proteus
+// clang-format on
 
 #include <cstdio>
 #include <cstdlib>
@@ -33,13 +37,14 @@ int main() {
   gpuErrCheck(gpuDeviceSynchronize());
   kernel<<<1, 1>>>(1.0);
   gpuErrCheck(gpuDeviceSynchronize());
+// CUDA AOT compilation with a `long double` breaks on lassen.
+// We re-test the `double` type with a different value (to avoid caching).
 #if PROTEUS_ENABLE_HIP
-  kernel<<<1, 1>>>(1.0l);
+  kernel<<<1, 1>>>(2.0l);
 #elif PROTEUS_ENABLE_CUDA
-  // CUDA AOT compilation with a `long double` breaks on lassen.
-  // We re-test the `double` type with a different value (to avoid caching) to
-  // re-use the lit CHECKs below.
   kernel<<<1, 1>>>(2.0);
+#else
+#error "Expected PROTEUS_ENABLE_HIP or PROTEUS_ENABLE_CUDA"
 #endif
   gpuErrCheck(gpuDeviceSynchronize());
   kernel<<<1, 1>>>(true);
@@ -50,16 +55,32 @@ int main() {
   gpuErrCheck(gpuDeviceSynchronize());
 }
 
-// CHECK: JitCache hits 0 total 12
-// CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-// CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-// CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-// CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-// CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-// CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-// CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-// CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-// CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-// CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-// CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-// CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
+// clang-format off
+// CHECK-FIRST: [ArgSpec] Replaced Function _Z6kernelIiEvT_ ArgNo 0 with value i32 1
+// CHECK-FIRST: [LaunchBoundSpec] GridSize 1 BlockSize 1
+// CHECK-FIRST: [ArgSpec] Replaced Function _Z6kernelIlEvT_ ArgNo 0 with value i64 1
+// CHECK-FIRST: [LaunchBoundSpec] GridSize 1 BlockSize 1
+// CHECK-FIRST: [ArgSpec] Replaced Function _Z6kernelIjEvT_ ArgNo 0 with value i32 1
+// CHECK-FIRST: [LaunchBoundSpec] GridSize 1 BlockSize 1
+// CHECK-FIRST: [ArgSpec] Replaced Function _Z6kernelImEvT_ ArgNo 0 with value i64 1
+// CHECK-FIRST: [LaunchBoundSpec] GridSize 1 BlockSize 1
+// CHECK-FIRST: [ArgSpec] Replaced Function _Z6kernelIxEvT_ ArgNo 0 with value i64 1
+// CHECK-FIRST: [LaunchBoundSpec] GridSize 1 BlockSize 1
+// CHECK-FIRST: [ArgSpec] Replaced Function _Z6kernelIyEvT_ ArgNo 0 with value i64 1
+// CHECK-FIRST: [LaunchBoundSpec] GridSize 1 BlockSize 1
+// CHECK-FIRST: [ArgSpec] Replaced Function _Z6kernelIfEvT_ ArgNo 0 with value float 1.000000e+00
+// CHECK-FIRST: [LaunchBoundSpec] GridSize 1 BlockSize 1
+// CHECK-FIRST: [ArgSpec] Replaced Function _Z6kernelIdEvT_ ArgNo 0 with value double 1.000000e+00
+// CHECK-FIRST: [LaunchBoundSpec] GridSize 1 BlockSize 1
+// HIP sees long double, CUDA sees double, thus the regex.
+// CHECK-FIRST: [ArgSpec] Replaced Function {{_Z6kernelI[ed]EvT_}} ArgNo 0 with value double 2.000000e+00
+// CHECK-FIRST: [LaunchBoundSpec] GridSize 1 BlockSize 1
+// CHECK-FIRST: [ArgSpec] Replaced Function _Z6kernelIbEvT_ ArgNo 0 with value i1 true
+// CHECK-FIRST: [LaunchBoundSpec] GridSize 1 BlockSize 1
+// CHECK-FIRST: [ArgSpec] Replaced Function _Z6kernelIcEvT_ ArgNo 0 with value i8 97
+// CHECK-FIRST: [LaunchBoundSpec] GridSize 1 BlockSize 1
+// CHECK-FIRST: [ArgSpec] Replaced Function _Z6kernelIhEvT_ ArgNo 0 with value i8 97
+// CHECK-FIRST: [LaunchBoundSpec] GridSize 1 BlockSize 1
+// CHECK-FIRST: JitCache hits 0 total 12
+// CHECK-COUNT-12: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
+// CHECK-SECOND: JitStorageCache hits 12 total 12


### PR DESCRIPTION
- Add PROTEUS_TRACE_OUTPUT env var to enable printing transform specialization information in stdout
- Add trace printouts to specializations
- Update tests to include specialization trace output in checks (non-cached run)
- Add labels for grouping tests: cpu, gpu, gpu-basic (non-RDC), gpu-rdc
- Update config in user docs