### PR TITLE
Refactor interface for runtime constant info

### DIFF
--- a/include/proteus/CompilationTask.hpp
+++ b/include/proteus/CompilationTask.hpp
@@ -22,8 +22,6 @@ private:
   std::string Suffix;
   dim3 BlockDim;
   dim3 GridDim;
-  SmallVector<int32_t> RCIndices;
-  ArrayRef<int32_t> RCTypes;
   SmallVector<RuntimeConstant> RCVec;
   SmallVector<std::pair<std::string, StringRef>> LambdaCalleeInfo;
   std::unordered_map<std::string, const void *> VarNameToDevPtr;
@@ -49,7 +47,6 @@ public:
   CompilationTask(
       MemoryBufferRef Bitcode, HashT HashValue, const std::string &KernelName,
       std::string &Suffix, dim3 BlockDim, dim3 GridDim,
-      const SmallVector<int32_t> &RCIndices, ArrayRef<int32_t> RCTypes,
       const SmallVector<RuntimeConstant> &RCVec,
       const SmallVector<std::pair<std::string, StringRef>> &LambdaCalleeInfo,
       const std::unordered_map<std::string, const void *> &VarNameToDevPtr,
@@ -58,8 +55,7 @@ public:
       bool RelinkGlobalsByCopy, bool SpecializeArgs, bool SpecializeDims,
       bool SpecializeLaunchBounds)
       : Bitcode(Bitcode), HashValue(HashValue), KernelName(KernelName),
-        Suffix(Suffix), BlockDim(BlockDim), GridDim(GridDim),
-        RCIndices(RCIndices), RCTypes(RCTypes), RCVec(RCVec),
+        Suffix(Suffix), BlockDim(BlockDim), GridDim(GridDim), RCVec(RCVec),
         LambdaCalleeInfo(LambdaCalleeInfo), VarNameToDevPtr(VarNameToDevPtr),
         GlobalLinkedBinaries(GlobalLinkedBinaries), DeviceArch(DeviceArch),
         CGOption(CGOption), DumpIR(DumpIR),
@@ -87,9 +83,9 @@ public:
 
     std::string KernelMangled = (KernelName + Suffix);
 
-    proteus::specializeIR(*M, KernelName, Suffix, BlockDim, GridDim, RCIndices,
-                          RCTypes, RCVec, LambdaCalleeInfo, SpecializeArgs,
-                          SpecializeDims, SpecializeLaunchBounds);
+    proteus::specializeIR(*M, KernelName, Suffix, BlockDim, GridDim, RCVec,
+                          LambdaCalleeInfo, SpecializeArgs, SpecializeDims,
+                          SpecializeLaunchBounds);
 
     replaceGlobalVariablesWithPointers(*M, VarNameToDevPtr);
 

--- a/include/proteus/CompilerInterfaceTypes.h
+++ b/include/proteus/CompilerInterfaceTypes.h
@@ -16,7 +16,7 @@
 
 namespace proteus {
 
-enum RuntimeConstantTypes : int32_t {
+enum RuntimeConstantType : int32_t {
   BOOL = 1,
   INT8,
   INT32,
@@ -27,9 +27,16 @@ enum RuntimeConstantTypes : int32_t {
   PTR
 };
 
+struct RuntimeConstantInfo {
+  RuntimeConstantType Type;
+  int32_t Pos;
+
+  explicit RuntimeConstantInfo(RuntimeConstantType Type, int32_t Pos)
+      : Type(Type), Pos(Pos) {}
+};
+
 struct RuntimeConstant {
-  RuntimeConstant() { std::memset(&Value, 0, sizeof(RuntimeConstantType)); }
-  using RuntimeConstantType = union {
+  using RuntimeConstantValue = union {
     bool BoolVal;
     int8_t Int8Val;
     int32_t Int32Val;
@@ -37,11 +44,27 @@ struct RuntimeConstant {
     float FloatVal;
     double DoubleVal;
     long double LongDoubleVal;
-    // TODO: This allows pointer as runtime constant values. How useful is that?
+    // TODO: This allows pointer as runtime constant values. How useful is
+    // that?
     void *PtrVal;
   };
-  RuntimeConstantType Value;
+  RuntimeConstantValue Value;
+  RuntimeConstantType Type;
+  int32_t Pos;
   int32_t Slot{-1};
+
+  explicit RuntimeConstant(RuntimeConstantType Type, int32_t Pos)
+      : Type(Type), Pos(Pos) {
+    std::memset(&Value, 0, sizeof(RuntimeConstantValue));
+  }
+  explicit RuntimeConstant() {
+    std::memset(&Value, 0, sizeof(RuntimeConstantValue));
+  }
+
+  RuntimeConstant(const RuntimeConstant &) = default;
+  RuntimeConstant(RuntimeConstant &&) = default;
+  RuntimeConstant &operator=(const RuntimeConstant &) = default;
+  RuntimeConstant &operator=(RuntimeConstant &&) = default;
 };
 
 } // namespace proteus

--- a/include/proteus/CoreLLVMDevice.hpp
+++ b/include/proteus/CoreLLVMDevice.hpp
@@ -256,8 +256,7 @@ inline void relinkGlobalsObject(
 
 inline void specializeIR(
     Module &M, StringRef FnName, StringRef Suffix, dim3 &BlockDim,
-    dim3 &GridDim, const SmallVector<int32_t> &RCIndices,
-    ArrayRef<int32_t> RCTypes, const SmallVector<RuntimeConstant> &RCVec,
+    dim3 &GridDim, ArrayRef<RuntimeConstant> RCArray,
     const SmallVector<std::pair<std::string, StringRef>> LambdaCalleeInfo,
     bool SpecializeArgs, bool SpecializeDims, bool SpecializeLaunchBounds) {
   Timer T;
@@ -266,8 +265,7 @@ inline void specializeIR(
   assert(F && "Expected non-null function!");
   // Replace argument uses with runtime constants.
   if (SpecializeArgs)
-    TransformArgumentSpecialization::transform(M, *F, RCIndices, RCTypes,
-                                               RCVec);
+    TransformArgumentSpecialization::transform(M, *F, RCArray);
 
   auto &LR = LambdaRegistry::instance();
   for (auto &[FnName, LambdaType] : LambdaCalleeInfo) {

--- a/include/proteus/Hashing.hpp
+++ b/include/proteus/Hashing.hpp
@@ -53,7 +53,7 @@ inline HashT hashArrayRefElement(const RuntimeConstant &RC) {
       StringRef{reinterpret_cast<const char *>(&RC.Value), sizeof(RC.Value)});
 }
 
-inline HashT hashValue(const ArrayRef<RuntimeConstant> &Arr) {
+inline HashT hashValue(ArrayRef<RuntimeConstant> Arr) {
   if (Arr.empty())
     return 0;
 

--- a/include/proteus/JitCache.hpp
+++ b/include/proteus/JitCache.hpp
@@ -47,7 +47,7 @@ public:
 
   void insert(HashT &HashValue, Function_t FunctionPtr,
               [[maybe_unused]] StringRef FnName,
-              [[maybe_unused]] ArrayRef<RuntimeConstant> RCArr) {
+              [[maybe_unused]] ArrayRef<RuntimeConstant> RCArray) {
 #if PROTEUS_ENABLE_DEBUG
     if (CacheMap.count(HashValue))
       PROTEUS_FATAL_ERROR("JitCache collision detected");
@@ -60,7 +60,7 @@ public:
 
 #if PROTEUS_ENABLE_DEBUG
     CacheEntry.FnName = FnName.str();
-    CacheEntry.RCVector = SmallVector<RuntimeConstant>{RCArr};
+    CacheEntry.RCVector = SmallVector<RuntimeConstant>{RCArray};
 #endif
   }
 

--- a/include/proteus/JitEngine.hpp
+++ b/include/proteus/JitEngine.hpp
@@ -43,10 +43,9 @@ public:
   void disable() { Config::get().ProteusDisable = true; }
 
 protected:
-  void getRuntimeConstantValues(void **KernelArgs,
-                                const ArrayRef<int32_t> RCIndices,
-                                const ArrayRef<int32_t> RCTypes,
-                                SmallVector<RuntimeConstant> &RCVec);
+  SmallVector<RuntimeConstant>
+  getRuntimeConstantValues(void **KernelArgs,
+                           ArrayRef<RuntimeConstantInfo *> RCInfoArray);
 
   JitEngine();
 

--- a/include/proteus/JitEngineHost.hpp
+++ b/include/proteus/JitEngineHost.hpp
@@ -41,12 +41,11 @@ public:
 
   Expected<orc::ThreadSafeModule>
   specializeIR(std::unique_ptr<Module> M, std::unique_ptr<LLVMContext> Ctx,
-               StringRef FnName, StringRef Suffix, ArrayRef<int32_t> RCTypes,
-               const SmallVector<RuntimeConstant> &RCVec);
+               StringRef FnName, StringRef Suffix,
+               ArrayRef<RuntimeConstant> RCArray);
 
   void *compileAndLink(StringRef FnName, char *IR, int IRSize, void **Args,
-                       int32_t *RCIndices, int32_t *RCTypes,
-                       int NumRuntimeConstants);
+                       ArrayRef<RuntimeConstantInfo *> RCInfoArray);
 
   void compileOnly(std::unique_ptr<Module> M);
 

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -3,6 +3,7 @@
 # globals in the target application.
 set(SOURCES
   CompilerInterfaceHost.cpp
+  CompilerInterfaceRuntimeConstantInfo.cpp
   JitEngine.cpp
   JitEngineHost.cpp
   Frontend/Func.cpp

--- a/src/lib/CompilerInterfaceDevice.cpp
+++ b/src/lib/CompilerInterfaceDevice.cpp
@@ -48,9 +48,11 @@ __jit_register_linked_binary(void *FatbinWrapper, const char *ModuleId) {
 
 extern "C" __attribute((used)) void
 __jit_register_function(void *Handle, void *Kernel, char *KernelName,
-                        int32_t *RCIndices, int32_t *RCTypes, int32_t NumRCs) {
+                        RuntimeConstantInfo **RCInfoArrayPtr, int32_t NumRCs) {
+  ArrayRef<RuntimeConstantInfo *> RCInfoArray{RCInfoArrayPtr,
+                                              static_cast<size_t>(NumRCs)};
   auto &Jit = JitDeviceImplT::instance();
-  Jit.registerFunction(Handle, Kernel, KernelName, RCIndices, RCTypes, NumRCs);
+  Jit.registerFunction(Handle, Kernel, KernelName, RCInfoArray);
 }
 
 extern "C" proteus::DeviceTraits<JitDeviceImplT>::DeviceError_t

--- a/src/lib/CompilerInterfaceHost.cpp
+++ b/src/lib/CompilerInterfaceHost.cpp
@@ -17,12 +17,13 @@ using namespace proteus;
 using namespace llvm;
 
 extern "C" __attribute__((used)) void *
-__jit_entry(char *FnName, char *IR, int IRSize, void **Args, int32_t *RCIndices,
-            int32_t *RCTypes, int NumRuntimeConstants) {
+__jit_entry(char *FnName, char *IR, int IRSize, void **Args,
+            RuntimeConstantInfo **RCInfoArrayPtr, int NumRuntimeConstants) {
   TIMESCOPE("__jit_entry");
   JitEngineHost &Jit = JitEngineHost::instance();
-  void *JitFnPtr = Jit.compileAndLink(FnName, IR, IRSize, Args, RCIndices,
-                                      RCTypes, NumRuntimeConstants);
+  ArrayRef<RuntimeConstantInfo *> RCInfoArray{
+      RCInfoArrayPtr, static_cast<size_t>(NumRuntimeConstants)};
+  void *JitFnPtr = Jit.compileAndLink(FnName, IR, IRSize, Args, RCInfoArray);
 
   return JitFnPtr;
 }

--- a/src/lib/CompilerInterfaceRuntimeConstantInfo.cpp
+++ b/src/lib/CompilerInterfaceRuntimeConstantInfo.cpp
@@ -1,0 +1,29 @@
+// NOLINTBEGIN(readability-identifier-naming)
+
+#include "proteus/CompilerInterfaceTypes.h"
+
+#include <llvm/Support/Debug.h>
+#include <llvm/Support/raw_ostream.h>
+
+#include <cstdio>
+#include <memory>
+
+using namespace proteus;
+using namespace llvm;
+
+SmallVectorImpl<std::unique_ptr<RuntimeConstantInfo>> &
+getRuntimeConstantInfoStorage() {
+  static SmallVector<std::unique_ptr<RuntimeConstantInfo>, 64> RCStorage;
+  return RCStorage;
+}
+
+extern "C" {
+RuntimeConstantInfo *
+__proteus_create_runtime_constant_info(RuntimeConstantType RCType,
+                                       int32_t Pos) {
+  auto &Ptr = getRuntimeConstantInfoStorage().emplace_back(
+      std::make_unique<RuntimeConstantInfo>(RCType, Pos));
+  return Ptr.get();
+}
+}
+// NOLINTEND(readability-identifier-naming)

--- a/src/lib/JitEngine.cpp
+++ b/src/lib/JitEngine.cpp
@@ -52,68 +52,70 @@ void JitEngine::optimizeIR(Module &M, StringRef Arch, char OptLevel,
   proteus::optimizeIR(M, Arch, OptLevel, CodegenOptLevel);
 }
 
-void JitEngine::getRuntimeConstantValues(void **Args,
-                                         const ArrayRef<int32_t> RCIndices,
-                                         const ArrayRef<int32_t> RCTypes,
-                                         SmallVector<RuntimeConstant> &RCVec) {
+SmallVector<RuntimeConstant> JitEngine::getRuntimeConstantValues(
+    void **Args, ArrayRef<RuntimeConstantInfo *> RCInfoArray) {
   TIMESCOPE(__FUNCTION__);
-  for (size_t I = 0; I < RCIndices.size(); ++I) {
-    PROTEUS_DBG(Logger::logs("proteus") << "RC Index " << RCIndices[I]
-                                        << " Type " << RCTypes[I] << " ");
-    RuntimeConstant RC;
-    switch (RCTypes[I]) {
-    case RuntimeConstantTypes::BOOL:
-      RC.Value.BoolVal = *(bool *)Args[RCIndices[I]];
+
+  SmallVector<RuntimeConstant> RCVec;
+  RCVec.reserve(RCInfoArray.size());
+  for (const auto *RCInfo : RCInfoArray) {
+    auto &RC = RCVec.emplace_back(RCInfo->Type, RCInfo->Pos);
+    PROTEUS_DBG(Logger::logs("proteus")
+                << "RC Index " << RC.Pos << " Type " << RC.Type << " ");
+
+    switch (RC.Type) {
+    case RuntimeConstantType::BOOL:
+      RC.Value.BoolVal = *(bool *)Args[RC.Pos];
       PROTEUS_DBG(Logger::logs("proteus")
                   << "Value " << RC.Value.BoolVal << "\n");
       break;
-    case RuntimeConstantTypes::INT8:
-      RC.Value.Int8Val = *(int8_t *)Args[RCIndices[I]];
+    case RuntimeConstantType::INT8:
+      RC.Value.Int8Val = *(int8_t *)Args[RC.Pos];
       PROTEUS_DBG(Logger::logs("proteus")
                   << "Value " << RC.Value.Int8Val << "\n");
       break;
       break;
-    case RuntimeConstantTypes::INT32:
-      RC.Value.Int32Val = *(int32_t *)Args[RCIndices[I]];
+    case RuntimeConstantType::INT32:
+      RC.Value.Int32Val = *(int32_t *)Args[RC.Pos];
       PROTEUS_DBG(Logger::logs("proteus")
                   << "Value " << RC.Value.Int32Val << "\n");
       break;
-    case RuntimeConstantTypes::INT64:
-      RC.Value.Int64Val = *(int64_t *)Args[RCIndices[I]];
+    case RuntimeConstantType::INT64:
+      RC.Value.Int64Val = *(int64_t *)Args[RC.Pos];
       PROTEUS_DBG(Logger::logs("proteus")
                   << "Value " << RC.Value.Int64Val << "\n");
       break;
-    case RuntimeConstantTypes::FLOAT:
-      RC.Value.FloatVal = *(float *)Args[RCIndices[I]];
+    case RuntimeConstantType::FLOAT:
+      RC.Value.FloatVal = *(float *)Args[RC.Pos];
       PROTEUS_DBG(Logger::logs("proteus")
                   << "Value " << RC.Value.FloatVal << "\n");
       break;
-    case RuntimeConstantTypes::DOUBLE:
-      RC.Value.DoubleVal = *(double *)Args[RCIndices[I]];
+    case RuntimeConstantType::DOUBLE:
+      RC.Value.DoubleVal = *(double *)Args[RC.Pos];
       PROTEUS_DBG(Logger::logs("proteus")
                   << "Value " << RC.Value.DoubleVal << "\n");
       break;
     // NOTE: long double on device should correspond to plain double.
     // XXX: CUDA with a long double SILENTLY fails to create a working
     // kernel in AOT compilation, with or without JIT.
-    case RuntimeConstantTypes::LONG_DOUBLE:
-      RC.Value.LongDoubleVal = *(long double *)Args[RCIndices[I]];
+    case RuntimeConstantType::LONG_DOUBLE:
+      RC.Value.LongDoubleVal = *(long double *)Args[RC.Pos];
       PROTEUS_DBG(Logger::logs("proteus")
                   << "Value " << std::to_string(RC.Value.LongDoubleVal)
                   << "\n");
       break;
-    case RuntimeConstantTypes::PTR:
-      RC.Value.PtrVal = (void *)*(intptr_t *)Args[RCIndices[I]];
+    case RuntimeConstantType::PTR:
+      RC.Value.PtrVal = (void *)*(intptr_t *)Args[RC.Pos];
       PROTEUS_DBG(Logger::logs("proteus")
                   << "Value " << RC.Value.PtrVal << "\n");
       break;
     default:
       PROTEUS_FATAL_ERROR("JIT Incompatible type in runtime constant: " +
-                          std::to_string(RCTypes[I]));
+                          std::to_string(RC.Type));
     }
-
-    RCVec.push_back(RC);
   }
+
+  return RCVec;
 }
 
 } // namespace proteus


### PR DESCRIPTION
- Introduce __proteus_create_runtime_constant_info to create runtime constant info and manage memory in the runtime library
- Initialize array of runtime constant info pointers once in the pass and provide to the runtime library
- Update the runtime library to use the runtime constant info pointer array to create vector of RuntimeConstant objects with values extracted at runtime

**More information**
The previous interface requires the pass to create 1D arrays of runtime constant info (types, indices) which is quite cumbersome to extend, especially if the metadata information is sparse and does not apply to all runtime constants. This change sets up creating the `proteus::jit_array` interface that will enable specializing for arrays of scalars.