### PR TITLE
Support object specialization

### DIFF
--- a/include/proteus/CoreLLVMDevice.hpp
+++ b/include/proteus/CoreLLVMDevice.hpp
@@ -262,6 +262,10 @@ inline void specializeIR(
   Timer T;
   Function *F = M.getFunction(FnName);
 
+#if PROTEUS_ENABLE_DEBUG
+  PROTEUS_DBG(Logger::logfile(FnName.str() + ".input.ll", M));
+#endif
+
   assert(F && "Expected non-null function!");
   // Replace argument uses with runtime constants.
   if (SpecializeArgs)

--- a/include/proteus/JitCache.hpp
+++ b/include/proteus/JitCache.hpp
@@ -46,8 +46,7 @@ public:
   }
 
   void insert(HashT &HashValue, Function_t FunctionPtr,
-              [[maybe_unused]] StringRef FnName,
-              [[maybe_unused]] ArrayRef<RuntimeConstant> RCArray) {
+              [[maybe_unused]] StringRef FnName) {
 #if PROTEUS_ENABLE_DEBUG
     if (CacheMap.count(HashValue))
       PROTEUS_FATAL_ERROR("JitCache collision detected");
@@ -60,7 +59,6 @@ public:
 
 #if PROTEUS_ENABLE_DEBUG
     CacheEntry.FnName = FnName.str();
-    CacheEntry.RCVector = SmallVector<RuntimeConstant>{RCArray};
 #endif
   }
 
@@ -72,15 +70,8 @@ public:
       std::cout << "HashValue " << HashValue.toString() << " NumExecs "
                 << JCE.NumExecs << " NumHits " << JCE.NumHits;
 #if PROTEUS_ENABLE_DEBUG
-      // outs() << " FnName " << JCE.FnName << " RCs [";
-      printf(" FnName %s RCs [", JCE.FnName.c_str());
-      for (auto &RC : JCE.RCVector)
-        // outs() << RC.Int64Val << ", ";
-        printf("%ld, ", RC.Value.Int64Val);
-      // outs() << "]";
-      printf("]");
+      printf(" FnName %s", JCE.FnName.c_str());
 #endif
-      // outs() << "\n";
       printf("\n");
     }
   }
@@ -94,7 +85,6 @@ private:
     uint64_t NumHits;
 #if PROTEUS_ENABLE_DEBUG
     std::string FnName;
-    SmallVector<RuntimeConstant> RCVector;
 #endif
   };
 

--- a/include/proteus/JitEngineDevice.hpp
+++ b/include/proteus/JitEngineDevice.hpp
@@ -617,7 +617,7 @@ JitEngineDevice<ImplT>::compileAndRun(
       auto KernelFunc =
           getKernelFunctionFromImage(KernelMangled, CacheBuf->getBufferStart());
 
-      CodeCache.insert(HashValue, KernelFunc, KernelInfo.getName(), RCVec);
+      CodeCache.insert(HashValue, KernelFunc, KernelInfo.getName());
 
       return launchKernelFunction(KernelFunc, GridDim, BlockDim, KernelArgs,
                                   ShmemSize, Stream);
@@ -679,7 +679,7 @@ JitEngineDevice<ImplT>::compileAndRun(
       KernelMangled, ObjBuf->getBufferStart(),
       Config::get().ProteusRelinkGlobalsByCopy, VarNameToDevPtr);
 
-  CodeCache.insert(HashValue, KernelFunc, KernelInfo.getName(), RCVec);
+  CodeCache.insert(HashValue, KernelFunc, KernelInfo.getName());
   if (Config::get().ProteusUseStoredCache) {
     StorageCache.store(HashValue, ObjBuf->getMemBufferRef());
   }

--- a/include/proteus/JitInterface.hpp
+++ b/include/proteus/JitInterface.hpp
@@ -52,18 +52,59 @@ jit_array(T V, [[maybe_unused]] size_t NumElts,
 #endif
 
 template <typename T>
-static __attribute__((noinline)) T jit_variable(T v, int pos = -1) {
-  RuntimeConstant RC;
-  std::memcpy(&RC, &v, sizeof(T));
-  RC.Slot = pos;
-  __jit_push_variable(RC);
+__attribute__((noinline)) void
+jit_object(T *V, size_t Size = sizeof(std::remove_pointer_t<T>)) noexcept;
 
-  return v;
+#if defined(__CUDACC__) || defined(__HIP__)
+template <typename T>
+__attribute__((noinline)) __device__ void
+jit_object(T *V, size_t Size = sizeof(T)) noexcept;
+#endif
+
+template <typename T>
+__attribute__((noinline)) void
+jit_object(T &V, size_t Size = sizeof(std::remove_reference_t<T>)) noexcept;
+
+#if defined(__CUDACC__) || defined(__HIP__)
+template <typename T>
+__attribute__((noinline)) __device__ void
+jit_object(T &V, size_t Size = sizeof(T)) noexcept;
+#endif
+
+template <typename T> inline static RuntimeConstantType convertCTypeToRCType() {
+  if constexpr (std::is_same_v<T, bool>) {
+    return RuntimeConstantType::BOOL;
+  } else if constexpr (std::is_integral_v<T> && sizeof(T) == sizeof(int8_t)) {
+    return RuntimeConstantType::INT8;
+  } else if constexpr (std::is_integral_v<T> && sizeof(T) == sizeof(int32_t)) {
+    return RuntimeConstantType::INT32;
+  } else if constexpr (std::is_integral_v<T> && sizeof(T) == sizeof(int64_t)) {
+    return RuntimeConstantType::INT64;
+  } else if constexpr (std::is_same_v<T, float>) {
+    return RuntimeConstantType::FLOAT;
+  } else if constexpr (std::is_same_v<T, double>) {
+    return RuntimeConstantType::DOUBLE;
+  } else if constexpr (std::is_same_v<T, long double>) {
+    return RuntimeConstantType::LONG_DOUBLE;
+  } else if constexpr (std::is_pointer_v<T>) {
+    return RuntimeConstantType::PTR;
+  } else {
+    return RuntimeConstantType::NONE;
+  }
 }
 
 template <typename T>
-static __attribute__((noinline)) T &&register_lambda(T &&t,
-                                                     const char *Symbol = "") {
+static __attribute__((noinline)) T jit_variable(T V, int Pos = -1) noexcept {
+  RuntimeConstant RC{convertCTypeToRCType<T>(), Pos};
+  std::memcpy(&RC, &V, sizeof(T));
+  __jit_push_variable(RC);
+
+  return V;
+}
+
+template <typename T>
+static __attribute__((noinline)) T &&
+register_lambda(T &&t, const char *Symbol = "") noexcept {
   assert(Symbol && "Expected non-null Symbol");
   __jit_register_lambda(Symbol);
   return std::forward<T>(t);

--- a/include/proteus/RuntimeConstantTypeHelpers.h
+++ b/include/proteus/RuntimeConstantTypeHelpers.h
@@ -35,6 +35,10 @@ inline RuntimeConstantType convertTypeToRuntimeConstantType(Type *Ty) {
     return RuntimeConstantType::LONG_DOUBLE;
   if (Ty->isPointerTy())
     return RuntimeConstantType::PTR;
+  if (Ty->isArrayTy())
+    return RuntimeConstantType::STATIC_ARRAY;
+  if (Ty->isVectorTy())
+    return RuntimeConstantType::VECTOR;
 
   std::string TypeString;
   raw_string_ostream TypeOstream(TypeString);
@@ -66,6 +70,50 @@ inline Type *convertRuntimeConstantTypeToLLVMType(RuntimeConstantType RCType,
   }
 }
 
+inline size_t getSizeInBytes(RuntimeConstantType RCType) {
+  switch (RCType) {
+  case RuntimeConstantType::BOOL:
+    return sizeof(bool);
+  case RuntimeConstantType::INT8:
+    return sizeof(int8_t);
+  case RuntimeConstantType::INT32:
+    return sizeof(int32_t);
+  case RuntimeConstantType::INT64:
+    return sizeof(int64_t);
+  case RuntimeConstantType::FLOAT:
+    return sizeof(float);
+  case RuntimeConstantType::DOUBLE:
+    return sizeof(double);
+  case RuntimeConstantType::LONG_DOUBLE:
+    return sizeof(long double);
+  default:
+    PROTEUS_FATAL_ERROR("Unknown size for RuntimeConstantType " +
+                        toString(RCType));
+  }
+}
+
+template <typename T> T getValue(const RuntimeConstant &RC) {
+  switch (RC.Type) {
+  case RuntimeConstantType::BOOL:
+    return RC.Value.BoolVal;
+  case RuntimeConstantType::INT8:
+    return RC.Value.Int8Val;
+  case RuntimeConstantType::INT32:
+    return RC.Value.Int32Val;
+  case RuntimeConstantType::INT64:
+    return RC.Value.Int64Val;
+  case RuntimeConstantType::FLOAT:
+    return RC.Value.FloatVal;
+  case RuntimeConstantType::DOUBLE:
+    return RC.Value.DoubleVal;
+  case RuntimeConstantType::LONG_DOUBLE:
+    return RC.Value.LongDoubleVal;
+  default:
+    PROTEUS_FATAL_ERROR("Cannot get value for RuntimeConstantType " +
+                        toString(RC.Type));
+  }
+}
+
 inline std::string toString(const RuntimeConstantType RCType) {
   switch (RCType) {
   case RuntimeConstantType::BOOL:
@@ -84,11 +132,22 @@ inline std::string toString(const RuntimeConstantType RCType) {
     return "LONG_DOUBLE";
   case RuntimeConstantType::PTR:
     return "PTR";
+  case RuntimeConstantType::STATIC_ARRAY:
+    return "STATIC_ARRAY";
+  case RuntimeConstantType::VECTOR:
+    return "VECTOR";
   case RuntimeConstantType::ARRAY:
     return "ARRAY";
+  case RuntimeConstantType::OBJECT:
+    return "OBJECT";
   default:
     PROTEUS_FATAL_ERROR("Unknown RCType " + std::to_string(RCType));
   }
+}
+
+inline bool isScalarRuntimeConstantType(RuntimeConstantType RCType) {
+  return (RCType >= RuntimeConstantType::BOOL &&
+          RCType <= RuntimeConstantType::PTR);
 }
 
 } // namespace proteus

--- a/include/proteus/TransformArgumentSpecialization.hpp
+++ b/include/proteus/TransformArgumentSpecialization.hpp
@@ -28,12 +28,60 @@ class TransformArgumentSpecialization {
 private:
   template <typename T>
   static ArrayRef<T> createArrayRef(const RuntimeConstant &RC) {
-    T *TypedPtr = static_cast<T *>(RC.Value.PtrVal);
+    T *TypedPtr = reinterpret_cast<T *>(RC.ArrInfo.Blob.get());
     if (RC.ArrInfo.NumElts <= 0)
       PROTEUS_FATAL_ERROR("Invalid number of elements in array: " +
                           std::to_string(RC.ArrInfo.NumElts));
 
     return ArrayRef<T>(TypedPtr, RC.ArrInfo.NumElts);
+  }
+
+  static Constant *createConstantDataArray(Module &M,
+                                           const RuntimeConstant &RC) {
+    //  Dispatch based on element type.
+    switch (RC.ArrInfo.EltType) {
+    case RuntimeConstantType::BOOL:
+      return ConstantDataArray::get(M.getContext(), createArrayRef<bool>(RC));
+    case RuntimeConstantType::INT8:
+      return ConstantDataArray::get(M.getContext(), createArrayRef<int8_t>(RC));
+    case RuntimeConstantType::INT32:
+      return ConstantDataArray::get(M.getContext(),
+                                    createArrayRef<int32_t>(RC));
+    case RuntimeConstantType::INT64:
+      return ConstantDataArray::get(M.getContext(),
+                                    createArrayRef<int64_t>(RC));
+    case RuntimeConstantType::FLOAT:
+      return ConstantDataArray::get(M.getContext(), createArrayRef<float>(RC));
+    case RuntimeConstantType::DOUBLE:
+      return ConstantDataArray::get(M.getContext(), createArrayRef<double>(RC));
+    default:
+      PROTEUS_FATAL_ERROR("Unsupported array element type: " +
+                          toString(RC.ArrInfo.EltType));
+    }
+  }
+
+  static Constant *createConstantDataVector(Module &M,
+                                            const RuntimeConstant &RC) {
+    //  Dispatch based on element type.
+    switch (RC.ArrInfo.EltType) {
+    case RuntimeConstantType::INT8:
+      return ConstantDataVector::get(M.getContext(),
+                                     createArrayRef<uint8_t>(RC));
+    case RuntimeConstantType::INT32:
+      return ConstantDataVector::get(M.getContext(),
+                                     createArrayRef<uint32_t>(RC));
+    case RuntimeConstantType::INT64:
+      return ConstantDataVector::get(M.getContext(),
+                                     createArrayRef<uint64_t>(RC));
+    case RuntimeConstantType::FLOAT:
+      return ConstantDataVector::get(M.getContext(), createArrayRef<float>(RC));
+    case RuntimeConstantType::DOUBLE:
+      return ConstantDataVector::get(M.getContext(),
+                                     createArrayRef<double>(RC));
+    default:
+      PROTEUS_FATAL_ERROR("Unsupported vector element type: " +
+                          toString(RC.ArrInfo.EltType));
+    }
   }
 
 public:
@@ -44,88 +92,93 @@ public:
     // Replace argument uses with runtime constants.
     for (const auto &RC : RCArray) {
       int ArgNo = RC.Pos;
-      Value *Arg = F.getArg(ArgNo);
+      Argument *Arg = F.getArg(ArgNo);
       Type *ArgType = Arg->getType();
       Constant *C = nullptr;
 
-      if (ArgType->isIntegerTy(1)) {
+      switch (RC.Type) {
+      case RuntimeConstantType::BOOL: {
         C = ConstantInt::get(ArgType, RC.Value.BoolVal);
-      } else if (ArgType->isIntegerTy(8)) {
+        break;
+      }
+      case RuntimeConstantType::INT8: {
         C = ConstantInt::get(ArgType, RC.Value.Int8Val);
-      } else if (ArgType->isIntegerTy(32)) {
-        // Logger::logs("proteus") << "RC is Int32\n";
+        break;
+      }
+      case RuntimeConstantType::INT32: {
         C = ConstantInt::get(ArgType, RC.Value.Int32Val);
-      } else if (ArgType->isIntegerTy(64)) {
-        // Logger::logs("proteus") << "RC is Int64\n";
+        break;
+      }
+      case RuntimeConstantType::INT64: {
         C = ConstantInt::get(ArgType, RC.Value.Int64Val);
-      } else if (ArgType->isFloatTy()) {
+        break;
+      }
+      case RuntimeConstantType::FLOAT: {
         // Logger::logs("proteus") << "RC is Float\n";
         C = ConstantFP::get(ArgType, RC.Value.FloatVal);
-      } else if (ArgType->isDoubleTy()) {
+        break;
+      }
+      case RuntimeConstantType::DOUBLE: {
+        C = ConstantFP::get(ArgType, RC.Value.DoubleVal);
+        break;
+      }
+      case RuntimeConstantType::LONG_DOUBLE: {
         // NOTE: long double on device should correspond to plain double.
         // XXX: CUDA with a long double SILENTLY fails to create a working
         // kernel in AOT compilation, with or without JIT.
-        if (RC.Type == RuntimeConstantType::LONG_DOUBLE)
-          C = ConstantFP::get(ArgType, RC.Value.LongDoubleVal);
-        else
-          C = ConstantFP::get(ArgType, RC.Value.DoubleVal);
-      } else if (ArgType->isX86_FP80Ty() || ArgType->isPPC_FP128Ty() ||
-                 ArgType->isFP128Ty()) {
         C = ConstantFP::get(ArgType, RC.Value.LongDoubleVal);
-      } else if (ArgType->isPointerTy()) {
-        if (RC.Type == RuntimeConstantType::PTR) {
-          auto *IntC =
-              ConstantInt::get(Type::getInt64Ty(Ctx), RC.Value.Int64Val);
-          C = ConstantExpr::getIntToPtr(IntC, ArgType);
-        } else if (RC.Type == RuntimeConstantType::ARRAY) {
-          auto CreateConstantDataArray = [&]() {
-            //  Dispatch based on element type.
-            switch (RC.ArrInfo.EltType) {
-            case RuntimeConstantType::BOOL:
-              return ConstantDataArray::get(M.getContext(),
-                                            createArrayRef<bool>(RC));
-            case RuntimeConstantType::INT8:
-              return ConstantDataArray::get(M.getContext(),
-                                            createArrayRef<int8_t>(RC));
-            case RuntimeConstantType::INT32:
-              return ConstantDataArray::get(M.getContext(),
-                                            createArrayRef<int32_t>(RC));
-            case RuntimeConstantType::INT64:
-              return ConstantDataArray::get(M.getContext(),
-                                            createArrayRef<int64_t>(RC));
-            case RuntimeConstantType::FLOAT:
-              return ConstantDataArray::get(M.getContext(),
-                                            createArrayRef<float>(RC));
-            case RuntimeConstantType::DOUBLE:
-              return ConstantDataArray::get(M.getContext(),
-                                            createArrayRef<double>(RC));
-            default:
-              PROTEUS_FATAL_ERROR("Unsupported array element type: " +
-                                  toString(RC.ArrInfo.EltType));
-            }
-          };
+        break;
+      }
+      case RuntimeConstantType::PTR: {
+        auto *IntC = ConstantInt::get(Type::getInt64Ty(Ctx), RC.Value.Int64Val);
+        C = ConstantExpr::getIntToPtr(IntC, ArgType);
+        break;
+      }
+      case RuntimeConstantType::ARRAY: {
+        Constant *CDA = createConstantDataArray(M, RC);
+        // Create a global variable to hold the array.
+        GlobalVariable *GV = new GlobalVariable(
+            M, CDA->getType(), true, GlobalValue::PrivateLinkage, CDA);
 
-          Constant *CDA = CreateConstantDataArray();
-          // Create a global variable to hold the array.
-          GlobalVariable *GV = new GlobalVariable(
-              M, CDA->getType(), true, GlobalValue::PrivateLinkage, CDA);
+        // Cast to the expected pointer type.
+        C = ConstantExpr::getBitCast(GV, ArgType);
+        break;
+      }
+      case RuntimeConstantType::STATIC_ARRAY: {
+        C = createConstantDataArray(M, RC);
+        break;
+      }
+      case RuntimeConstantType::VECTOR: {
+        C = createConstantDataVector(M, RC);
+        break;
+      }
+      case RuntimeConstantType::OBJECT: {
+        Constant *CDA = ConstantDataArray::getRaw(
+            StringRef{reinterpret_cast<const char *>(RC.ObjInfo.Blob.get()),
+                      static_cast<size_t>(RC.ObjInfo.Size)},
+            RC.ObjInfo.Size, Type::getInt8Ty(M.getContext()));
+        // Create a global variable to hold the array.
+        GlobalVariable *GV = new GlobalVariable(
+            M, CDA->getType(), true, GlobalValue::PrivateLinkage, CDA);
 
-          // Cast to the expected pointer type.
-          C = ConstantExpr::getBitCast(GV, ArgType);
-        }
-      } else {
+        // Cast to the expected pointer type.
+        C = ConstantExpr::getPointerBitCastOrAddrSpaceCast(GV, ArgType);
+        break;
+      }
+      default: {
         std::string TypeString;
         raw_string_ostream TypeOstream(TypeString);
         ArgType->print(TypeOstream);
         PROTEUS_FATAL_ERROR("JIT Incompatible type in runtime constant: " +
                             TypeOstream.str());
       }
+      }
 
       auto TraceOut = [](Function &F, int ArgNo, Constant *C) {
         SmallString<128> S;
         raw_svector_ostream OS(S);
         OS << "[ArgSpec] Replaced Function " << F.getName() << " ArgNo "
-           << ArgNo << " with value " << *C << "\n";
+           << ArgNo << " with value " << *C->stripPointerCasts() << "\n";
 
         return S;
       };

--- a/include/proteus/TransformLambdaSpecialization.hpp
+++ b/include/proteus/TransformLambdaSpecialization.hpp
@@ -68,7 +68,7 @@ public:
 #if PROTEUS_ENABLE_DEBUG
     for (auto &Arg : RCVec) {
       Logger::logs("proteus")
-          << "{" << Arg.Value.Int64Val << ", " << Arg.Slot << " }\n";
+          << "{" << Arg.Value.Int64Val << ", " << Arg.Pos << " }\n";
     }
 #endif
 
@@ -85,12 +85,12 @@ public:
       PROTEUS_DBG(Logger::logs("proteus") << *User << "\n");
       if (isa<LoadInst>(User)) {
         for (auto &Arg : RCVec) {
-          if (Arg.Slot == 0) {
+          if (Arg.Pos == 0) {
             Constant *C = getConstant(M.getContext(), User->getType(), Arg);
             User->replaceAllUsesWith(C);
-            PROTEUS_DBG(Logger::logs("proteus") << TraceOut(Arg.Slot, C));
+            PROTEUS_DBG(Logger::logs("proteus") << TraceOut(Arg.Pos, C));
             if (Config::get().ProteusTraceOutput)
-              Logger::trace(TraceOut(Arg.Slot, C));
+              Logger::trace(TraceOut(Arg.Pos, C));
           }
         }
       } else if (auto *GEP = dyn_cast<GetElementPtrInst>(User)) {
@@ -98,7 +98,7 @@ public:
         ConstantInt *CI = dyn_cast<ConstantInt>(GEPSlot);
         int Slot = CI->getZExtValue();
         for (auto &Arg : RCVec) {
-          if (Arg.Slot == Slot) {
+          if (Arg.Pos == Slot) {
             for (auto *GEPUser : GEP->users()) {
               auto *LI = dyn_cast<LoadInst>(GEPUser);
               if (!LI)
@@ -106,9 +106,9 @@ public:
               Type *LoadType = LI->getType();
               Constant *C = getConstant(M.getContext(), LoadType, Arg);
               LI->replaceAllUsesWith(C);
-              PROTEUS_DBG(Logger::logs("proteus") << TraceOut(Arg.Slot, C));
+              PROTEUS_DBG(Logger::logs("proteus") << TraceOut(Arg.Pos, C));
               if (Config::get().ProteusTraceOutput)
-                Logger::trace(TraceOut(Arg.Slot, C));
+                Logger::trace(TraceOut(Arg.Pos, C));
             }
           }
         }

--- a/src/lib/CompilerInterfaceRuntimeConstantInfo.cpp
+++ b/src/lib/CompilerInterfaceRuntimeConstantInfo.cpp
@@ -43,5 +43,12 @@ RuntimeConstantInfo *__proteus_create_runtime_constant_info_array_runconst_size(
                                             NumEltsPos));
   return Ptr.get();
 }
+
+RuntimeConstantInfo *__proteus_create_runtime_constant_info_object(
+    RuntimeConstantType RCType, int32_t Pos, int32_t Size, bool PassByValue) {
+  auto &Ptr = getRuntimeConstantInfoStorage().emplace_back(
+      std::make_unique<RuntimeConstantInfo>(RCType, Pos, Size, PassByValue));
+  return Ptr.get();
+}
 }
 // NOLINTEND(readability-identifier-naming)

--- a/src/lib/JitEngine.cpp
+++ b/src/lib/JitEngine.cpp
@@ -74,53 +74,132 @@ template <typename T> inline static T getRuntimeConstantValue(void *Arg) {
   }
 }
 
-inline static void dispatchGetRuntimeConstantValue(void *Arg,
-                                                   RuntimeConstantType RCType,
-                                                   RuntimeConstantValue &RV) {
-  switch (RCType) {
+inline static RuntimeConstant
+dispatchGetRuntimeConstantValue(void **Args,
+                                const RuntimeConstantInfo &RCInfo) {
+  RuntimeConstant RC{RCInfo.ArgInfo.Type, RCInfo.ArgInfo.Pos};
+
+  void *Arg = Args[RC.Pos];
+  switch (RC.Type) {
   case RuntimeConstantType::BOOL:
-    RV.BoolVal = getRuntimeConstantValue<bool>(Arg);
-    PROTEUS_DBG(Logger::logs("proteus") << "Value " << RV.BoolVal << "\n");
+    RC.Value.BoolVal = getRuntimeConstantValue<bool>(Arg);
+    PROTEUS_DBG(Logger::logs("proteus")
+                << "Value " << RC.Value.BoolVal << "\n");
     break;
   case RuntimeConstantType::INT8:
-    RV.Int8Val = getRuntimeConstantValue<int8_t>(Arg);
-    PROTEUS_DBG(Logger::logs("proteus") << "Value " << RV.Int8Val << "\n");
+    RC.Value.Int8Val = getRuntimeConstantValue<int8_t>(Arg);
+    PROTEUS_DBG(Logger::logs("proteus")
+                << "Value " << RC.Value.Int8Val << "\n");
     break;
   case RuntimeConstantType::INT32:
-    RV.Int32Val = getRuntimeConstantValue<int32_t>(Arg);
-    PROTEUS_DBG(Logger::logs("proteus") << "Value " << RV.Int32Val << "\n");
+    RC.Value.Int32Val = getRuntimeConstantValue<int32_t>(Arg);
+    PROTEUS_DBG(Logger::logs("proteus")
+                << "Value " << RC.Value.Int32Val << "\n");
     break;
   case RuntimeConstantType::INT64:
-    RV.Int64Val = getRuntimeConstantValue<int64_t>(Arg);
-    PROTEUS_DBG(Logger::logs("proteus") << "Value " << RV.Int64Val << "\n");
+    RC.Value.Int64Val = getRuntimeConstantValue<int64_t>(Arg);
+    PROTEUS_DBG(Logger::logs("proteus")
+                << "Value " << RC.Value.Int64Val << "\n");
     break;
   case RuntimeConstantType::FLOAT:
-    RV.FloatVal = getRuntimeConstantValue<float>(Arg);
-    PROTEUS_DBG(Logger::logs("proteus") << "Value " << RV.FloatVal << "\n");
+    RC.Value.FloatVal = getRuntimeConstantValue<float>(Arg);
+    PROTEUS_DBG(Logger::logs("proteus")
+                << "Value " << RC.Value.FloatVal << "\n");
     break;
   case RuntimeConstantType::DOUBLE:
-    RV.DoubleVal = getRuntimeConstantValue<double>(Arg);
-    PROTEUS_DBG(Logger::logs("proteus") << "Value " << RV.DoubleVal << "\n");
+    RC.Value.DoubleVal = getRuntimeConstantValue<double>(Arg);
+    PROTEUS_DBG(Logger::logs("proteus")
+                << "Value " << RC.Value.DoubleVal << "\n");
     break;
   case RuntimeConstantType::LONG_DOUBLE:
     // NOTE: long double on device should correspond to plain double.
     // XXX: CUDA with a long double SILENTLY fails to create a working
     // kernel in AOT compilation, with or without JIT.
-    RV.LongDoubleVal = getRuntimeConstantValue<long double>(Arg);
+    RC.Value.LongDoubleVal = getRuntimeConstantValue<long double>(Arg);
     PROTEUS_DBG(Logger::logs("proteus")
-                << "Value " << std::to_string(RV.LongDoubleVal) << "\n");
+                << "Value " << std::to_string(RC.Value.LongDoubleVal) << "\n");
     break;
   case RuntimeConstantType::PTR:
-    RV.PtrVal = (void *)getRuntimeConstantValue<intptr_t>(Arg);
-    PROTEUS_DBG(Logger::logs("proteus") << "Value " << RV.PtrVal << "\n");
+    RC.Value.PtrVal = (void *)getRuntimeConstantValue<intptr_t>(Arg);
+    PROTEUS_DBG(Logger::logs("proteus") << "Value " << RC.Value.PtrVal << "\n");
     break;
-  case RuntimeConstantType::ARRAY:
-    RV.PtrVal = (void *)getRuntimeConstantValue<intptr_t>(Arg);
+  case RuntimeConstantType::ARRAY: {
+    int32_t NumElts;
+    if (RCInfo.OptArrInfo->OptNumEltsRCInfo) {
+      int32_t NumEltsPos = RCInfo.OptArrInfo->OptNumEltsRCInfo->Pos;
+      RuntimeConstantType NumEltsType =
+          RCInfo.OptArrInfo->OptNumEltsRCInfo->Type;
+
+      RuntimeConstantInfo NumEltsRCInfo{NumEltsType, NumEltsPos};
+      RuntimeConstant NumEltsRC =
+          dispatchGetRuntimeConstantValue(Args, NumEltsRCInfo);
+
+      NumElts = getValue<int32_t>(NumEltsRC);
+    } else {
+      NumElts = RCInfo.OptArrInfo->NumElts;
+    }
+
+    size_t SizeInBytes = NumElts * getSizeInBytes(RCInfo.OptArrInfo->EltType);
+    std::shared_ptr<unsigned char[]> Blob{new unsigned char[SizeInBytes]};
+    // The interface is a pointer-to-pointer so we need to deref it to copy the
+    // data.
+    void *Src = (void *)getRuntimeConstantValue<intptr_t>(Arg);
+    std::memcpy(Blob.get(), Src, SizeInBytes);
+
+    RC.ArrInfo = ArrayInfo{NumElts, RCInfo.OptArrInfo->EltType, Blob};
+
+    PROTEUS_DBG(Logger::logs("proteus") << "Value Blob " << Blob << "\n");
     break;
+  }
+  case RuntimeConstantType::STATIC_ARRAY: {
+    size_t SizeInBytes =
+        RCInfo.OptArrInfo->NumElts * getSizeInBytes(RCInfo.OptArrInfo->EltType);
+    std::shared_ptr<unsigned char[]> Blob{new unsigned char[SizeInBytes]};
+    // Static arrays are passed by value, so it is a pointer directly to the
+    // stack.
+    std::memcpy(Blob.get(), Arg, SizeInBytes);
+
+    RC.ArrInfo =
+        ArrayInfo{RCInfo.OptArrInfo->NumElts, RCInfo.OptArrInfo->EltType, Blob};
+
+    PROTEUS_DBG(Logger::logs("proteus") << "Value " << RC.Value.PtrVal << "\n");
+    break;
+  }
+  case RuntimeConstantType::VECTOR: {
+    size_t SizeInBytes =
+        RCInfo.OptArrInfo->NumElts * getSizeInBytes(RCInfo.OptArrInfo->EltType);
+    std::shared_ptr<unsigned char[]> Blob{new unsigned char[SizeInBytes]};
+    // Vectors are passed by value, so it is a pointer directly to the stack.
+    std::memcpy(Blob.get(), Arg, SizeInBytes);
+
+    RC.ArrInfo =
+        ArrayInfo{RCInfo.OptArrInfo->NumElts, RCInfo.OptArrInfo->EltType, Blob};
+
+    PROTEUS_DBG(Logger::logs("proteus") << "Value " << RC.Value.PtrVal << "\n");
+    break;
+  }
+  case RuntimeConstantType::OBJECT: {
+    std::shared_ptr<unsigned char[]> Blob{
+        new unsigned char[RCInfo.OptObjInfo->Size]};
+
+    void *Src = (RCInfo.OptObjInfo->PassByValue
+                     ? Args[RCInfo.ArgInfo.Pos]
+                     : (void *)getRuntimeConstantValue<intptr_t>(
+                           Args[RCInfo.ArgInfo.Pos]));
+    std::memcpy(Blob.get(), Src, RCInfo.OptObjInfo->Size);
+
+    RC.ObjInfo = ObjectInfo{RCInfo.OptObjInfo->Size,
+                            RCInfo.OptObjInfo->PassByValue, Blob};
+
+    PROTEUS_DBG(Logger::logs("proteus") << "Value " << RC.Value.PtrVal << "\n");
+    break;
+  }
   default:
     PROTEUS_FATAL_ERROR("Unsupported runtime constant type: " +
-                        std::to_string(RCType));
+                        toString(RC.Type));
   }
+
+  return RC;
 }
 
 SmallVector<RuntimeConstant> JitEngine::getRuntimeConstantValues(
@@ -130,32 +209,11 @@ SmallVector<RuntimeConstant> JitEngine::getRuntimeConstantValues(
   SmallVector<RuntimeConstant> RCVec;
   RCVec.reserve(RCInfoArray.size());
   for (const auto *RCInfo : RCInfoArray) {
-    auto &RC = RCVec.emplace_back(RCInfo->ArgInfo.Type, RCInfo->ArgInfo.Pos);
-
     PROTEUS_DBG(Logger::logs("proteus")
-                << "RC Index " << RC.Pos << " Type " << RC.Type << " ");
+                << "RC Index " << RCInfo->ArgInfo.Pos << " Type "
+                << toString(RCInfo->ArgInfo.Type) << " ");
 
-    void *Arg = Args[RC.Pos];
-
-    dispatchGetRuntimeConstantValue(Arg, RC.Type, RC.Value);
-    // Resolve NumElts for runtime constant arrays.
-    if (RCInfo->ArgInfo.Type == RuntimeConstantType::ARRAY) {
-      if (RCInfo->OptArrInfo->OptNumEltsRCInfo) {
-        int32_t NumEltsPos = RCInfo->OptArrInfo->OptNumEltsRCInfo->Pos;
-        RuntimeConstantType NumEltsType =
-            RCInfo->OptArrInfo->OptNumEltsRCInfo->Type;
-
-        RuntimeConstantValue RV;
-        dispatchGetRuntimeConstantValue(Args[NumEltsPos], NumEltsType, RV);
-
-        RC.ArrInfo = ArrayInfo{static_cast<int32_t>(RV.Int64Val),
-                               RCInfo->OptArrInfo->EltType};
-
-      } else {
-        RC.ArrInfo =
-            ArrayInfo{RCInfo->OptArrInfo->NumElts, RCInfo->OptArrInfo->EltType};
-      }
-    }
+    RCVec.emplace_back(dispatchGetRuntimeConstantValue(Args, *RCInfo));
   }
 
   return RCVec;

--- a/src/lib/JitEngineHost.cpp
+++ b/src/lib/JitEngineHost.cpp
@@ -260,7 +260,7 @@ Expected<orc::ThreadSafeModule> JitEngineHost::specializeIR(
   F->setName(FnName + Suffix);
 
 #if PROTEUS_ENABLE_DEBUG
-  Logger::logfile(FnName.str() + ".final.ll", *M);
+  Logger::logfile(FnName.str() + ".specialized.ll", *M);
   if (verifyModule(*M, &errs()))
     PROTEUS_FATAL_ERROR("Broken module found, JIT compilation aborted!");
   else
@@ -349,7 +349,7 @@ JitEngineHost::compileAndLink(StringRef FnName, char *IR, int IRSize,
               << "FnName " << FnName << " Mangled " << MangledFnName
               << " address " << JitFnPtr << "\n");
   assert(JitFnPtr && "Expected non-null JIT function pointer");
-  CodeCache.insert(HashValue, JitFnPtr, FnName, RCVec);
+  CodeCache.insert(HashValue, JitFnPtr, FnName);
 
   Logger::logs("proteus") << "=== JIT compile: " << FnName << " Mangled "
                           << MangledFnName << " RC HashValue "

--- a/src/pass/AnnotationHandler.h
+++ b/src/pass/AnnotationHandler.h
@@ -71,6 +71,10 @@ private:
       SmallPtrSetImpl<Function *> &JitArrayAnnotations,
       DenseMap<Function *, SmallSetVector<RuntimeConstantInfo, 16>> &RCInfoMap);
 
+  void parseJitObjectAnnotations(
+      SmallPtrSetImpl<Function *> &JitObjectAnnotations,
+      DenseMap<Function *, SmallSetVector<RuntimeConstantInfo, 16>> &RCInfoMap);
+
   void parseAttributeAnnotations(
       GlobalVariable *GlobalAnnotations,
       MapVector<Function *, JitFunctionInfo> &JitFunctionInfoMap);

--- a/tests/cpu/CMakeLists.txt
+++ b/tests/cpu/CMakeLists.txt
@@ -29,6 +29,7 @@ endfunction()
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/lit.cfg.py "
 import lit.formats
 import os
+import platform
 
 config.name = 'LIT tests'
 config.test_format = lit.formats.ShTest(True)
@@ -39,6 +40,7 @@ config.test_source_root = '${CMAKE_CURRENT_SOURCE_DIR}'
 config.test_exec_root = '${CMAKE_CURRENT_BINARY_DIR}'
 FILECHECK = lit_config.params['FILECHECK']
 config.substitutions.append(('%FILECHECK', FILECHECK))
+config.substitutions.append(('%target_arch', platform.machine()))
 "
 )
 
@@ -54,3 +56,4 @@ CREATE_CPU_TEST(lambda_multiple lambda_multiple.cpp)
 CREATE_CPU_TEST(lambda_multiple_api lambda_multiple_api.cpp)
 CREATE_CPU_TEST(types_jit_array types_jit_array.cpp)
 CREATE_CPU_TEST(dynamic_jit_array dynamic_jit_array.cpp)
+CREATE_CPU_TEST(jit_struct jit_struct.cpp)

--- a/tests/cpu/jit_struct.cpp
+++ b/tests/cpu/jit_struct.cpp
@@ -1,0 +1,153 @@
+// clang-format off
+// RUN: rm -rf .proteus
+// RUN: PROTEUS_TRACE_OUTPUT=1 ./jit_struct | %FILECHECK %s --check-prefixes=CHECK,CHECK-%target_arch
+// clang-format on
+
+#include <climits>
+#include <cstdio>
+
+#include <proteus/JitInterface.hpp>
+
+struct DimInt {
+  int X, Y, Z;
+};
+
+struct DimDouble {
+  double X, Y, Z;
+};
+
+struct DimFloat {
+  float X, Y, Z;
+};
+
+struct DimMix {
+  int X;
+  double Y;
+  float Z;
+};
+
+struct DimFill {
+  int X, Y, Z;
+  int Fill[16];
+};
+
+template <typename DimT> void testByPtr(DimT *A) {
+  proteus::jit_object(A);
+  printf("A X %lf Y %lf Z %lf\n", static_cast<double>(A->X),
+         static_cast<double>(A->Y), static_cast<double>(A->Z));
+}
+template <typename DimT> void testByRef(DimT &A) {
+  proteus::jit_object(A);
+  printf("A X %lf Y %lf Z %lf\n", static_cast<double>(A.X),
+         static_cast<double>(A.Y), static_cast<double>(A.Z));
+}
+
+template <typename DimT> void testByVal(DimT A) {
+  proteus::jit_object(A);
+  printf("A X %lf Y %lf Z %lf\n", static_cast<double>(A.X),
+         static_cast<double>(A.Y), static_cast<double>(A.Z));
+}
+
+template <typename DimT> void launcher(int Init) {
+  DimT A;
+
+  std::memset(&A, 0, sizeof(DimT));
+
+  // Initialize.
+  A.X = Init + 3;
+  A.Y = Init + 2;
+  A.Z = Init + 1;
+
+  testByPtr(&A);
+  testByRef(A);
+  testByVal(A);
+}
+
+int main() {
+  proteus::init();
+
+  launcher<DimInt>(0);
+  launcher<DimFloat>(0);
+  launcher<DimDouble>(0);
+  launcher<DimMix>(0);
+  launcher<DimFill>(0);
+
+  launcher<DimInt>(100);
+  launcher<DimFloat>(100);
+  launcher<DimDouble>(100);
+  launcher<DimFill>(100);
+
+  proteus::finalize();
+  return 0;
+}
+
+// clang-format off
+// CHECK: [ArgSpec] Replaced Function _Z9testByPtrI6DimIntEvPT_ ArgNo 0 with value @0 = private constant [12 x i8] c"\03\00\00\00\02\00\00\00\01\00\00\00"
+// CHECK: A X 3.000000 Y 2.000000 Z 1.000000
+// CHECK: [ArgSpec] Replaced Function _Z9testByRefI6DimIntEvRT_ ArgNo 0 with value @0 = private constant [12 x i8] c"\03\00\00\00\02\00\00\00\01\00\00\00"
+// CHECK: A X 3.000000 Y 2.000000 Z 1.000000
+// CHECK-x86_64: [ArgSpec] Replaced Function _Z9testByValI6DimIntEvT_ ArgNo 0 with value i64 8589934595
+// CHECK-x86_64: [ArgSpec] Replaced Function _Z9testByValI6DimIntEvT_ ArgNo 1 with value i32 1
+// CHECK-ppc64le: [ArgSpec] Replaced Function _Z9testByValI6DimIntEvT_ ArgNo 0 with value [2 x i64] [i64 8589934595, i64 1]
+// CHECK: A X 3.000000 Y 2.000000 Z 1.000000
+// CHECK: [ArgSpec] Replaced Function _Z9testByPtrI8DimFloatEvPT_ ArgNo 0 with value @0 = private constant [12 x i8] c"\00\00@@\00\00\00@\00\00\80?"
+// CHECK: A X 3.000000 Y 2.000000 Z 1.000000
+// CHECK: [ArgSpec] Replaced Function _Z9testByRefI8DimFloatEvRT_ ArgNo 0 with value @0 = private constant [12 x i8] c"\00\00@@\00\00\00@\00\00\80?"
+// CHECK: A X 3.000000 Y 2.000000 Z 1.000000
+// CHECK-x86_64: [ArgSpec] Replaced Function _Z9testByValI8DimFloatEvT_ ArgNo 0 with value <2 x float> <float 3.000000e+00, float 2.000000e+00>
+// CHECK-x86_64: [ArgSpec] Replaced Function _Z9testByValI8DimFloatEvT_ ArgNo 1 with value float 1.000000e+00
+// CHECK-ppc64le: [ArgSpec] Replaced Function _Z9testByValI8DimFloatEvT_ ArgNo 0 with value [3 x float] [float 3.000000e+00, float 2.000000e+00, float 1.000000e+00]
+// CHECK: A X 3.000000 Y 2.000000 Z 1.000000
+// CHECK: [ArgSpec] Replaced Function _Z9testByPtrI9DimDoubleEvPT_ ArgNo 0 with value @0 = private constant [24 x i8] c"\00\00\00\00\00\00\08@\00\00\00\00\00\00\00@\00\00\00\00\00\00\F0?"
+// CHECK: A X 3.000000 Y 2.000000 Z 1.000000
+// CHECK: [ArgSpec] Replaced Function _Z9testByRefI9DimDoubleEvRT_ ArgNo 0 with value @0 = private constant [24 x i8] c"\00\00\00\00\00\00\08@\00\00\00\00\00\00\00@\00\00\00\00\00\00\F0?"
+// CHECK: A X 3.000000 Y 2.000000 Z 1.000000
+// CHECK-x86_64: [ArgSpec] Replaced Function _Z9testByValI9DimDoubleEvT_ ArgNo 0 with value @0 = private constant [24 x i8] c"\00\00\00\00\00\00\08@\00\00\00\00\00\00\00@\00\00\00\00\00\00\F0?"
+// CHECK-ppc64le: [ArgSpec] Replaced Function _Z9testByValI9DimDoubleEvT_ ArgNo 0 with value [3 x double] [double 3.000000e+00, double 2.000000e+00, double 1.000000e+00]
+// CHECK: A X 3.000000 Y 2.000000 Z 1.000000
+// CHECK: [ArgSpec] Replaced Function _Z9testByPtrI6DimMixEvPT_ ArgNo 0 with value @0 = private constant [24 x i8] c"\03\00\00\00\00\00\00\00\00\00\00\00\00\00\00@\00\00\80?\00\00\00\00"
+// CHECK: A X 3.000000 Y 2.000000 Z 1.000000
+// CHECK: [ArgSpec] Replaced Function _Z9testByRefI6DimMixEvRT_ ArgNo 0 with value @0 = private constant [24 x i8] c"\03\00\00\00\00\00\00\00\00\00\00\00\00\00\00@\00\00\80?\00\00\00\00"
+// CHECK: A X 3.000000 Y 2.000000 Z 1.000000
+// CHECK-x86_64: [ArgSpec] Replaced Function _Z9testByValI6DimMixEvT_ ArgNo 0 with value @0 = private constant [24 x i8] c"\03\00\00\00\00\00\00\00\00\00\00\00\00\00\00@\00\00\80?\00\00\00\00"
+// CHECK-ppc64le: [ArgSpec] Replaced Function _Z9testByValI6DimMixEvT_ ArgNo 0 with value [3 x i64] [i64 3, i64 4611686018427387904, i64 1065353216]
+// CHECK: A X 3.000000 Y 2.000000 Z 1.000000
+// CHECK: [ArgSpec] Replaced Function _Z9testByPtrI7DimFillEvPT_ ArgNo 0 with value @0 = private constant [76 x i8] c"\03\00\00\00\02\00\00\00\01\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00"
+// CHECK: A X 3.000000 Y 2.000000 Z 1.000000
+// CHECK: [ArgSpec] Replaced Function _Z9testByRefI7DimFillEvRT_ ArgNo 0 with value @0 = private constant [76 x i8] c"\03\00\00\00\02\00\00\00\01\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00"
+// CHECK: A X 3.000000 Y 2.000000 Z 1.000000
+// CHECK-x86_64: [ArgSpec] Replaced Function _Z9testByValI7DimFillEvT_ ArgNo 0 with value @0 = private constant [76 x i8] c"\03\00\00\00\02\00\00\00\01\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00"
+// CHECK-ppc64le: [ArgSpec] Replaced Function _Z9testByValI7DimFillEvT_ ArgNo 0 with value @0 = private constant [76 x i8] c"\03\00\00\00\02\00\00\00\01\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00"
+// CHECK: A X 3.000000 Y 2.000000 Z 1.000000
+// CHECK: [ArgSpec] Replaced Function _Z9testByPtrI6DimIntEvPT_ ArgNo 0 with value @0 = private constant [12 x i8] c"g\00\00\00f\00\00\00e\00\00\00"
+// CHECK: A X 103.000000 Y 102.000000 Z 101.000000
+// CHECK: [ArgSpec] Replaced Function _Z9testByRefI6DimIntEvRT_ ArgNo 0 with value @0 = private constant [12 x i8] c"g\00\00\00f\00\00\00e\00\00\00"
+// CHECK: A X 103.000000 Y 102.000000 Z 101.000000
+// CHECK-x86_64: [ArgSpec] Replaced Function _Z9testByValI6DimIntEvT_ ArgNo 0 with value i64 438086664295
+// CHECK-x86_64: [ArgSpec] Replaced Function _Z9testByValI6DimIntEvT_ ArgNo 1 with value i32 101
+// CHECK-ppc64le: [ArgSpec] Replaced Function _Z9testByValI6DimIntEvT_ ArgNo 0 with value [2 x i64] [i64 438086664295, i64 101]
+// CHECK: A X 103.000000 Y 102.000000 Z 101.000000
+// CHECK: [ArgSpec] Replaced Function _Z9testByPtrI8DimFloatEvPT_ ArgNo 0 with value @0 = private constant [12 x i8] c"\00\00\CEB\00\00\CCB\00\00\CAB"
+// CHECK: A X 103.000000 Y 102.000000 Z 101.000000
+// CHECK: [ArgSpec] Replaced Function _Z9testByRefI8DimFloatEvRT_ ArgNo 0 with value @0 = private constant [12 x i8] c"\00\00\CEB\00\00\CCB\00\00\CAB"
+// CHECK: A X 103.000000 Y 102.000000 Z 101.000000
+// CHECK-x86_64: [ArgSpec] Replaced Function _Z9testByValI8DimFloatEvT_ ArgNo 0 with value <2 x float> <float 1.030000e+02, float 1.020000e+02>
+// CHECK-x86_64: [ArgSpec] Replaced Function _Z9testByValI8DimFloatEvT_ ArgNo 1 with value float 1.010000e+02
+// CHECK-ppc64le: [ArgSpec] Replaced Function _Z9testByValI8DimFloatEvT_ ArgNo 0 with value [3 x float] [float 1.030000e+02, float 1.020000e+02, float 1.010000e+02]
+// CHECK: A X 103.000000 Y 102.000000 Z 101.000000
+// CHECK: [ArgSpec] Replaced Function _Z9testByPtrI9DimDoubleEvPT_ ArgNo 0 with value @0 = private constant [24 x i8] c"\00\00\00\00\00\C0Y@\00\00\00\00\00\80Y@\00\00\00\00\00@Y@"
+// CHECK: A X 103.000000 Y 102.000000 Z 101.000000
+// CHECK: [ArgSpec] Replaced Function _Z9testByRefI9DimDoubleEvRT_ ArgNo 0 with value @0 = private constant [24 x i8] c"\00\00\00\00\00\C0Y@\00\00\00\00\00\80Y@\00\00\00\00\00@Y@"
+// CHECK: A X 103.000000 Y 102.000000 Z 101.000000
+// CHECK-x86_64: [ArgSpec] Replaced Function _Z9testByValI9DimDoubleEvT_ ArgNo 0 with value @0 = private constant [24 x i8] c"\00\00\00\00\00\C0Y@\00\00\00\00\00\80Y@\00\00\00\00\00@Y@"
+// CHECK-ppc64le: [ArgSpec] Replaced Function _Z9testByValI9DimDoubleEvT_ ArgNo 0 with value [3 x double] [double 1.030000e+02, double 1.020000e+02, double 1.010000e+02]
+// CHECK: A X 103.000000 Y 102.000000 Z 101.000000
+// CHECK: [ArgSpec] Replaced Function _Z9testByPtrI7DimFillEvPT_ ArgNo 0 with value @0 = private constant [76 x i8] c"g\00\00\00f\00\00\00e\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00"
+// CHECK: A X 103.000000 Y 102.000000 Z 101.000000
+// CHECK: [ArgSpec] Replaced Function _Z9testByRefI7DimFillEvRT_ ArgNo 0 with value @0 = private constant [76 x i8] c"g\00\00\00f\00\00\00e\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00"
+// CHECK: A X 103.000000 Y 102.000000 Z 101.000000
+// CHECK-x86_64: [ArgSpec] Replaced Function _Z9testByValI7DimFillEvT_ ArgNo 0 with value @0 = private constant [76 x i8] c"g\00\00\00f\00\00\00e\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00"
+// CHECK-ppc64le: [ArgSpec] Replaced Function _Z9testByValI7DimFillEvT_ ArgNo 0 with value @0 = private constant [76 x i8] c"g\00\00\00f\00\00\00e\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00"
+// CHECK: A X 103.000000 Y 102.000000 Z 101.000000
+// CHECK: JitCache hits 0 total 27
+// CHECK-COUNT-27: HashValue {{[0-9]+}} NumExecs 1 NumHits 0

--- a/tests/gpu/CMakeLists.txt
+++ b/tests/gpu/CMakeLists.txt
@@ -287,6 +287,7 @@ endif()
 CREATE_GPU_TEST(mix_attr_api mix_attr_api.cpp)
 CREATE_GPU_TEST(types_jit_array types_jit_array.cpp)
 CREATE_GPU_TEST(dynamic_jit_array dynamic_jit_array.cpp)
+CREATE_GPU_TEST(jit_struct jit_struct.cpp)
 
 CREATE_GPU_TEST_RDC(kernel kernel.cpp)
 CREATE_GPU_TEST_RDC(kernel_cache kernel_cache.cpp)
@@ -345,6 +346,7 @@ CREATE_GPU_TEST_RDC_LIBS(kernel_calls_func_lib_api device_func_lib kernel_calls_
 CREATE_GPU_TEST_RDC(mix_attr_api mix_attr_api.cpp)
 CREATE_GPU_TEST_RDC(types_jit_array types_jit_array.cpp)
 CREATE_GPU_TEST_RDC(dynamic_jit_array dynamic_jit_array.cpp)
+CREATE_GPU_TEST_RDC(jit_struct jit_struct.cpp)
 
 if(PROTEUS_ENABLE_HIP)
     if(LLVM_VERSION_MAJOR GREATER_EQUAL 18)

--- a/tests/gpu/jit_struct.cpp
+++ b/tests/gpu/jit_struct.cpp
@@ -1,0 +1,152 @@
+// clang-format off
+// RUN: rm -rf .proteus
+// RUN: PROTEUS_TRACE_OUTPUT=1 ./jit_struct.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// Second run uses the object cache.
+// RUN: ./jit_struct.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf .proteus
+// clang-format on
+
+#include <climits>
+#include <cstdio>
+
+#include "gpu_common.h"
+
+#include <proteus/JitInterface.hpp>
+
+struct DimInt {
+  int X, Y, Z;
+};
+
+struct DimDouble {
+  double X, Y, Z;
+};
+
+struct DimFloat {
+  float X, Y, Z;
+};
+
+struct DimMix {
+  int X;
+  double Y;
+  float Z;
+};
+
+struct DimFill {
+  int X, Y, Z;
+  int Fill[10];
+};
+
+template <typename DimT> __global__ void testByPtr(DimT *A) {
+  proteus::jit_object(A);
+  printf("A X %lf Y %lf Z %lf\n", static_cast<double>(A->X),
+         static_cast<double>(A->Y), static_cast<double>(A->Z));
+}
+template <typename DimT> __global__ void testByRef(DimT &A) {
+  proteus::jit_object(A);
+  printf("A X %lf Y %lf Z %lf\n", static_cast<double>(A.X),
+         static_cast<double>(A.Y), static_cast<double>(A.Z));
+}
+
+template <typename DimT> __global__ void testByVal(DimT A) {
+  proteus::jit_object(A);
+  printf("A X %lf Y %lf Z %lf\n", static_cast<double>(A.X),
+         static_cast<double>(A.Y), static_cast<double>(A.Z));
+}
+
+template <typename DimT> void launcher(int Init) {
+  DimT *A;
+  gpuErrCheck(gpuMallocManaged(&A, sizeof(DimT)));
+  std::memset(A, 0, sizeof(DimT));
+
+  // Initialize.
+  A->X = Init + 3;
+  A->Y = Init + 2;
+  A->Z = Init + 1;
+
+  testByPtr<<<1, 1>>>(A);
+  gpuErrCheck(gpuDeviceSynchronize());
+  testByRef<<<1, 1>>>(*A);
+  gpuErrCheck(gpuDeviceSynchronize());
+  testByVal<<<1, 1>>>(*A);
+  gpuErrCheck(gpuDeviceSynchronize());
+
+  gpuErrCheck(gpuFree(A));
+}
+
+int main() {
+  proteus::init();
+
+  launcher<DimInt>(0);
+  launcher<DimFloat>(0);
+  launcher<DimDouble>(0);
+  launcher<DimMix>(0);
+  launcher<DimFill>(0);
+
+  launcher<DimInt>(100);
+  launcher<DimFloat>(100);
+  launcher<DimDouble>(100);
+  launcher<DimFill>(100);
+
+  proteus::finalize();
+  return 0;
+}
+
+// clang-format off
+// CHECK-FIRST: [ArgSpec] Replaced Function _Z9testByPtrI6DimIntEvPT_ ArgNo 0 with value @0 = private {{.*}}constant [12 x i8] c"\03\00\00\00\02\00\00\00\01\00\00\00"
+// CHECK: A X 3.000000 Y 2.000000 Z 1.000000
+// CHECK-FIRST: [ArgSpec] Replaced Function _Z9testByRefI6DimIntEvRT_ ArgNo 0 with value @0 = private {{.*}}constant [12 x i8] c"\03\00\00\00\02\00\00\00\01\00\00\00"
+// CHECK: A X 3.000000 Y 2.000000 Z 1.000000
+// CHECK-FIRST: [ArgSpec] Replaced Function _Z9testByValI6DimIntEvT_ ArgNo 0 with value @0 = private {{.*}}constant [12 x i8] c"\03\00\00\00\02\00\00\00\01\00\00\00"
+// CHECK: A X 3.000000 Y 2.000000 Z 1.000000
+// CHECK-FIRST: [ArgSpec] Replaced Function _Z9testByPtrI8DimFloatEvPT_ ArgNo 0 with value @0 = private {{.*}}constant [12 x i8] c"\00\00@@\00\00\00@\00\00\80?"
+// CHECK: A X 3.000000 Y 2.000000 Z 1.000000
+// CHECK-FIRST: [ArgSpec] Replaced Function _Z9testByRefI8DimFloatEvRT_ ArgNo 0 with value @0 = private {{.*}}constant [12 x i8] c"\00\00@@\00\00\00@\00\00\80?"
+// CHECK: A X 3.000000 Y 2.000000 Z 1.000000
+// CHECK-FIRST: [ArgSpec] Replaced Function _Z9testByValI8DimFloatEvT_ ArgNo 0 with value @0 = private {{.*}}constant [12 x i8] c"\00\00@@\00\00\00@\00\00\80?"
+// CHECK: A X 3.000000 Y 2.000000 Z 1.000000
+// CHECK-FIRST: [ArgSpec] Replaced Function _Z9testByPtrI9DimDoubleEvPT_ ArgNo 0 with value @0 = private {{.*}}constant [24 x i8] c"\00\00\00\00\00\00\08@\00\00\00\00\00\00\00@\00\00\00\00\00\00\F0?"
+// CHECK: A X 3.000000 Y 2.000000 Z 1.000000
+// CHECK-FIRST: [ArgSpec] Replaced Function _Z9testByRefI9DimDoubleEvRT_ ArgNo 0 with value @0 = private {{.*}}constant [24 x i8] c"\00\00\00\00\00\00\08@\00\00\00\00\00\00\00@\00\00\00\00\00\00\F0?"
+// CHECK: A X 3.000000 Y 2.000000 Z 1.000000
+// CHECK-FIRST: [ArgSpec] Replaced Function _Z9testByValI9DimDoubleEvT_ ArgNo 0 with value @0 = private {{.*}}constant [24 x i8] c"\00\00\00\00\00\00\08@\00\00\00\00\00\00\00@\00\00\00\00\00\00\F0?"
+// CHECK: A X 3.000000 Y 2.000000 Z 1.000000
+// CHECK-FIRST: [ArgSpec] Replaced Function _Z9testByPtrI6DimMixEvPT_ ArgNo 0 with value @0 = private {{.*}}constant [24 x i8] c"\03\00\00\00\00\00\00\00\00\00\00\00\00\00\00@\00\00\80?\00\00\00\00"
+// CHECK: A X 3.000000 Y 2.000000 Z 1.000000
+// CHECK-FIRST: [ArgSpec] Replaced Function _Z9testByRefI6DimMixEvRT_ ArgNo 0 with value @0 = private {{.*}}constant [24 x i8] c"\03\00\00\00\00\00\00\00\00\00\00\00\00\00\00@\00\00\80?\00\00\00\00"
+// CHECK: A X 3.000000 Y 2.000000 Z 1.000000
+// CHECK-FIRST: [ArgSpec] Replaced Function _Z9testByValI6DimMixEvT_ ArgNo 0 with value @0 = private {{.*}}constant [24 x i8] c"\03\00\00\00\00\00\00\00\00\00\00\00\00\00\00@\00\00\80?\00\00\00\00"
+// CHECK: A X 3.000000 Y 2.000000 Z 1.000000
+// CHECK-FIRST: [ArgSpec] Replaced Function _Z9testByPtrI7DimFillEvPT_ ArgNo 0 with value @0 = private {{.*}}constant [52 x i8] c"\03\00\00\00\02\00\00\00\01\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00"
+// CHECK: A X 3.000000 Y 2.000000 Z 1.000000
+// CHECK-FIRST: [ArgSpec] Replaced Function _Z9testByRefI7DimFillEvRT_ ArgNo 0 with value @0 = private {{.*}}constant [52 x i8] c"\03\00\00\00\02\00\00\00\01\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00"
+// CHECK: A X 3.000000 Y 2.000000 Z 1.000000
+// CHECK-FIRST: [ArgSpec] Replaced Function _Z9testByValI7DimFillEvT_ ArgNo 0 with value @0 = private {{.*}}constant [52 x i8] c"\03\00\00\00\02\00\00\00\01\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00"
+// CHECK: A X 3.000000 Y 2.000000 Z 1.000000
+// CHECK-FIRST: [ArgSpec] Replaced Function _Z9testByPtrI6DimIntEvPT_ ArgNo 0 with value @0 = private {{.*}}constant [12 x i8] c"g\00\00\00f\00\00\00e\00\00\00"
+// CHECK: A X 103.000000 Y 102.000000 Z 101.000000
+// CHECK-FIRST: [ArgSpec] Replaced Function _Z9testByRefI6DimIntEvRT_ ArgNo 0 with value @0 = private {{.*}}constant [12 x i8] c"g\00\00\00f\00\00\00e\00\00\00"
+// CHECK: A X 103.000000 Y 102.000000 Z 101.000000
+// CHECK-FIRST: [ArgSpec] Replaced Function _Z9testByValI6DimIntEvT_ ArgNo 0 with value @0 = private {{.*}}constant [12 x i8] c"g\00\00\00f\00\00\00e\00\00\00"
+// CHECK: A X 103.000000 Y 102.000000 Z 101.000000
+// CHECK-FIRST: [ArgSpec] Replaced Function _Z9testByPtrI8DimFloatEvPT_ ArgNo 0 with value @0 = private {{.*}}constant [12 x i8] c"\00\00\CEB\00\00\CCB\00\00\CAB"
+// CHECK: A X 103.000000 Y 102.000000 Z 101.000000
+// CHECK-FIRST: [ArgSpec] Replaced Function _Z9testByRefI8DimFloatEvRT_ ArgNo 0 with value @0 = private {{.*}}constant [12 x i8] c"\00\00\CEB\00\00\CCB\00\00\CAB"
+// CHECK: A X 103.000000 Y 102.000000 Z 101.000000
+// CHECK-FIRST: [ArgSpec] Replaced Function _Z9testByValI8DimFloatEvT_ ArgNo 0 with value @0 = private {{.*}}constant [12 x i8] c"\00\00\CEB\00\00\CCB\00\00\CAB"
+// CHECK: A X 103.000000 Y 102.000000 Z 101.000000
+// CHECK-FIRST: [ArgSpec] Replaced Function _Z9testByPtrI9DimDoubleEvPT_ ArgNo 0 with value @0 = private {{.*}}constant [24 x i8] c"\00\00\00\00\00\C0Y@\00\00\00\00\00\80Y@\00\00\00\00\00@Y@"
+// CHECK: A X 103.000000 Y 102.000000 Z 101.000000
+// CHECK-FIRST: [ArgSpec] Replaced Function _Z9testByRefI9DimDoubleEvRT_ ArgNo 0 with value @0 = private {{.*}}constant [24 x i8] c"\00\00\00\00\00\C0Y@\00\00\00\00\00\80Y@\00\00\00\00\00@Y@"
+// CHECK: A X 103.000000 Y 102.000000 Z 101.000000
+// CHECK-FIRST: [ArgSpec] Replaced Function _Z9testByValI9DimDoubleEvT_ ArgNo 0 with value @0 = private {{.*}}constant [24 x i8] c"\00\00\00\00\00\C0Y@\00\00\00\00\00\80Y@\00\00\00\00\00@Y@"
+// CHECK: A X 103.000000 Y 102.000000 Z 101.000000
+// CHECK-FIRST: [ArgSpec] Replaced Function _Z9testByPtrI7DimFillEvPT_ ArgNo 0 with value @0 = private {{.*}}constant [52 x i8] c"g\00\00\00f\00\00\00e\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00"
+// CHECK: A X 103.000000 Y 102.000000 Z 101.000000
+// CHECK-FIRST: [ArgSpec] Replaced Function _Z9testByRefI7DimFillEvRT_ ArgNo 0 with value @0 = private {{.*}}constant [52 x i8] c"g\00\00\00f\00\00\00e\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00"
+// CHECK: A X 103.000000 Y 102.000000 Z 101.000000
+// CHECK-FIRST: [ArgSpec] Replaced Function _Z9testByValI7DimFillEvT_ ArgNo 0 with value @0 = private {{.*}}constant [52 x i8] c"g\00\00\00f\00\00\00e\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00"
+// CHECK: A X 103.000000 Y 102.000000 Z 101.000000
+// CHECK: JitCache hits 0 total 27
+// CHECK-COUNT-27: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
+// CHECK-FIRST: JitStorageCache hits 0 total 27
+// CHECK-SECOND: JitStorageCache hits 27 total 27


### PR DESCRIPTION
- Introduce the proteus::jit_object inteface to specialize for trivially copyable objects
- Detect argument coercion (scalars, vectors) for JIT objects and make those coerced arguments as runtime constants and improve analysis
- Support runtime constant info for objects, also static arrays and vectors since they are used for argument coercion
- Update push JIT variable for lambdas to type the runtime constant
- Use the runtime constant type as the authoritative source for argument specialization
- Simplify JIT cache insertion interface to avoid copying the runtime constant vector
- Add tests