### PR TITLE
[cpp-frontend] Add more type checking and reduce overhead

### DIFF
--- a/include/proteus/Frontend/DispatcherCUDA.hpp
+++ b/include/proteus/Frontend/DispatcherCUDA.hpp
@@ -40,22 +40,6 @@ public:
     return StorageCache.lookup(ModuleHash);
   }
 
-  DispatchResult launch(StringRef KernelName, LaunchDims GridDim,
-                        LaunchDims BlockDim, ArrayRef<void *> KernelArgs,
-                        uint64_t ShmemSize, void *Stream,
-                        std::optional<MemoryBufferRef> ObjectModule) override {
-    auto *KernelFunc = getFunctionAddress(KernelName, ObjectModule);
-
-    dim3 CudaGridDim = {GridDim.X, GridDim.Y, GridDim.Z};
-    dim3 CudaBlockDim = {BlockDim.X, BlockDim.Y, BlockDim.Z};
-    cudaStream_t CudaStream = reinterpret_cast<cudaStream_t>(Stream);
-
-    void **KernelArgsPtrs = const_cast<void **>(KernelArgs.data());
-    return proteus::launchKernelFunction(
-        reinterpret_cast<cudaFunction_t>(KernelFunc), CudaGridDim, CudaBlockDim,
-        KernelArgsPtrs, ShmemSize, CudaStream);
-  }
-
   DispatchResult launch(void *KernelFunc, LaunchDims GridDim,
                         LaunchDims BlockDim, ArrayRef<void *> KernelArgs,
                         uint64_t ShmemSize, void *Stream) override {

--- a/include/proteus/Frontend/DispatcherHIP.hpp
+++ b/include/proteus/Frontend/DispatcherHIP.hpp
@@ -32,22 +32,6 @@ public:
     return StorageCache.lookup(ModuleHash);
   }
 
-  DispatchResult launch(StringRef KernelName, LaunchDims GridDim,
-                        LaunchDims BlockDim, ArrayRef<void *> KernelArgs,
-                        uint64_t ShmemSize, void *Stream,
-                        std::optional<MemoryBufferRef> ObjectModule) override {
-    auto *KernelFunc = getFunctionAddress(KernelName, ObjectModule);
-
-    dim3 HipGridDim = {GridDim.X, GridDim.Y, GridDim.Z};
-    dim3 HipBlockDim = {BlockDim.X, BlockDim.Y, BlockDim.Z};
-    hipStream_t HipStream = reinterpret_cast<hipStream_t>(Stream);
-
-    void **KernelArgsPtrs = const_cast<void **>(KernelArgs.data());
-    return proteus::launchKernelFunction(
-        reinterpret_cast<hipFunction_t>(KernelFunc), HipGridDim, HipBlockDim,
-        KernelArgsPtrs, ShmemSize, HipStream);
-  }
-
   DispatchResult launch(void *KernelFunc, LaunchDims GridDim,
                         LaunchDims BlockDim, ArrayRef<void *> KernelArgs,
                         uint64_t ShmemSize, void *Stream) override {

--- a/include/proteus/Frontend/DispatcherHost.hpp
+++ b/include/proteus/Frontend/DispatcherHost.hpp
@@ -29,12 +29,6 @@ public:
     return nullptr;
   }
 
-  DispatchResult launch(StringRef, LaunchDims, LaunchDims, ArrayRef<void *>,
-                        uint64_t, void *,
-                        std::optional<MemoryBufferRef>) override {
-    PROTEUS_FATAL_ERROR("Host does not support launch");
-  }
-
   DispatchResult launch(void *, LaunchDims, LaunchDims, ArrayRef<void *>,
                         uint64_t, void *) override {
     PROTEUS_FATAL_ERROR("Host does not support launch");

--- a/tests/frontend/cpu/cpp_source.cpp
+++ b/tests/frontend/cpu/cpp_source.cpp
@@ -33,8 +33,10 @@ int main() {
 
   int V = 42;
   CppJitModule CJM{"host", Code};
-  CJM.run<void>("foo_byval", V);
-  CJM.run<void(int &)>("foo_byref", V);
+  auto FooByVal = CJM.getFunction<void(int)>("foo_byval");
+  auto FooByRef = CJM.getFunction<void(int &)>("foo_byref");
+  FooByVal.run(V);
+  FooByRef.run(V);
 
   std::cout << "main V " << V << "\n";
 

--- a/tests/frontend/gpu/cpp_instantiate.cpp
+++ b/tests/frontend/gpu/cpp_instantiate.cpp
@@ -77,9 +77,9 @@ int main() {
 // CHECK: Ret 24
 // CHECK: bar type double
 // CHECK: bar type float
-// CHECK: JitCache hits 1 total 4
+// CHECK: JitCache hits 0 total 3
 // CHECK-DAG: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
-// CHECK-DAG: HashValue {{[0-9]+}} NumExecs 2 NumHits 1
+// CHECK-DAG: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
 // CHECK-DAG: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
 // CHECK-FIRST: JitStorageCache hits 0 total 3
 // CHECK-SECOND: JitStorageCache hits 3 total 3

--- a/tests/frontend/gpu/cpp_source.cpp
+++ b/tests/frontend/gpu/cpp_source.cpp
@@ -33,7 +33,8 @@ int main() {
    )cpp";
 
   CppJitModule CJM{TARGET, Code};
-  CJM.launch("foo", {1, 1, 1}, {1, 1, 1}, 0, nullptr, 42);
+  auto Kernel = CJM.getKernel<void(int)>("foo");
+  Kernel.launch({1, 1, 1}, {1, 1, 1}, 0, nullptr, 42);
   gpuErrCheck(gpuDeviceSynchronize());
 }
 

--- a/tests/integration/hip/cmake-clang_plugin-proteusFrontend/main.cpp
+++ b/tests/integration/hip/cmake-clang_plugin-proteusFrontend/main.cpp
@@ -12,7 +12,8 @@ int main() {
 })cpp";
 
   CppJitModule CJM{"host", Code, {"-fplugin=./libClangPlugin.so"}};
-  CJM.run<void>("foo");
+  auto Foo = CJM.getFunction<void()>("foo");
+  Foo.run();
 
   return 0;
 }

--- a/tests/integration/hip/cmake-proteusFrontend/main.cpp
+++ b/tests/integration/hip/cmake-proteusFrontend/main.cpp
@@ -15,8 +15,9 @@ int main() {
     }
   )cpp";
 
-  CppJitModule CJM("host", CPUCode);
-  CJM.run<void>("foo");
+  CppJitModule CJM{"host", CPUCode};
+  auto Foo = CJM.getFunction<void()>("foo");
+  Foo.run();
 
   const char *GPUCode = R"cpp(
     #include <hip/hip_runtime.h>
@@ -27,7 +28,8 @@ int main() {
   )cpp";
 
   CppJitModule CJMGPU{"hip", GPUCode};
-  CJMGPU.launch("foo", {1, 1, 1}, {1, 1, 1}, 0, nullptr);
+  auto FooKernel = CJMGPU.getKernel<void()>("foo");
+  FooKernel.launch({1, 1, 1}, {1, 1, 1}, 0, nullptr);
   if (hipDeviceSynchronize() != HIP_SUCCESS)
     throw std::runtime_error("hipDeviceSynchronize failed");
 


### PR DESCRIPTION
- Add typed KernelHandle, FunctionHandle stateful objects that cache the function pointer avoiding cache lookups by function name
- Introduce type checking requiring the function signature in run, launch interfaces