### PR TITLE
[cpp-frontend] Update default optimization levels

### DIFF
--- a/src/lib/Frontend/CppJitModule.cpp
+++ b/src/lib/Frontend/CppJitModule.cpp
@@ -72,8 +72,7 @@ void CppJitModule::compileCppToDynamicLibrary() {
       PROTEUS_CLANGXX_BIN,
       "-shared",
       "-std=c++17",
-      "-Xclang",
-      "-disable-O0-optnone",
+      "-O3",
       "-x",
       (TargetModel == TargetModelType::HOST_HIP ? "hip" : "cuda"),
       "-fPIC",
@@ -132,9 +131,15 @@ CppJitModule::CompilationResult CppJitModule::compileCppToIR() {
   // discovers and other options that are needed for source lowering.
   std::vector<std::string> ArgStorage;
   if (TargetModel == TargetModelType::HOST) {
-    ArgStorage = {
-        PROTEUS_CLANGXX_BIN,   "-emit-llvm", "-S",  "-std=c++17", "-Xclang",
-        "-disable-O0-optnone", "-x",         "c++", "-fPIC",      SourceName};
+    ArgStorage = {PROTEUS_CLANGXX_BIN,
+                  "-emit-llvm",
+                  "-S",
+                  "-std=c++17",
+                  "-O1",
+                  "-x",
+                  "c++",
+                  "-fPIC",
+                  SourceName};
   } else {
     std::string OffloadArch =
         "--offload-arch=" + Dispatch.getDeviceArch().str();
@@ -142,8 +147,7 @@ CppJitModule::CompilationResult CppJitModule::compileCppToIR() {
                   "-emit-llvm",
                   "-S",
                   "-std=c++17",
-                  "-Xclang",
-                  "-disable-O0-optnone",
+                  "-O1",
                   "-x",
                   (TargetModel == TargetModelType::HIP ? "hip" : "cuda"),
                   "--offload-device-only",


### PR DESCRIPTION
- Change to O1 in compileCppToIR to avoid optimization blockers to the JIT engine, e.g., O0 adds noinline which we can't remove easily like optnone.
- Change to O3 in compileCppToDynamicLibrary to maximize optimization by default since producing a binary

Either way those can be overriden by the user using the ExtraArgs interface.