### PR TITLE
Fix lifetime bug in device dispatchers

### DIFF
--- a/include/proteus/Frontend/DispatcherHIP.hpp
+++ b/include/proteus/Frontend/DispatcherHIP.hpp
@@ -16,10 +16,15 @@ public:
     return D;
   }
 
-  std::unique_ptr<MemoryBuffer>
-  compile([[maybe_unused]] std::unique_ptr<LLVMContext> Ctx,
-          std::unique_ptr<Module> M, HashT ModuleHash) override {
-    std::unique_ptr<MemoryBuffer> ObjectModule = Jit.compileOnly(*M);
+  std::unique_ptr<MemoryBuffer> compile(std::unique_ptr<LLVMContext> Ctx,
+                                        std::unique_ptr<Module> Mod,
+                                        HashT ModuleHash) override {
+    // This is necessary to ensure Ctx outlives M. Setting [[maybe_unused]] can
+    // trigger a lifetime bug.
+    auto CtxOwner = std::move(Ctx);
+    auto ModOwner = std::move(Mod);
+
+    std::unique_ptr<MemoryBuffer> ObjectModule = Jit.compileOnly(*ModOwner);
     if (!ObjectModule)
       PROTEUS_FATAL_ERROR("Expected non-null object library");
 


### PR DESCRIPTION
- Remove [[maybe_unused]] from Ctx in the compile() method and move Ctx, Mod to owners to ensure context destroys after module