### PR TITLE
Fix linking bug with proteus and non-proteus compiled objects

### DIFF
--- a/src/pass/ProteusPass.cpp
+++ b/src/pass/ProteusPass.cpp
@@ -244,40 +244,6 @@ private:
     runCleanupPassPipeline(*JitMod);
     runOptimizationPassPipeline(*JitMod);
 
-    // Update linkage and visibility in the original module only for
-    // globals included in the JIT module required for external
-    // linking.
-    for (auto &GVar : M.globals()) {
-      [[maybe_unused]] auto PrintGVarInfo = [](auto &GVar) {
-        Logger::logs("proteus-pass") << "=== GVar\n";
-        Logger::logs("proteus-pass") << GVar.getName() << "\n";
-        Logger::logs("proteus-pass") << "Linkage " << GVar.getLinkage() << "\n";
-        Logger::logs("proteus-pass")
-            << "Visibility " << GVar.getVisibility() << "\n";
-        Logger::logs("proteus-pass") << "=== End GV\n";
-      };
-
-      if (VMap[&GVar]) {
-        DEBUG(PrintGVarInfo(GVar));
-
-        if (GVar.isConstant())
-          continue;
-
-        if (GVar.getName() == "llvm.global_ctors") {
-          DEBUG(Logger::logs("proteus-pass") << "Skip llvm.global_ctors");
-          continue;
-        }
-
-        if (GVar.hasAvailableExternallyLinkage()) {
-          DEBUG(Logger::logs("proteus-pass") << "Skip available externally");
-          continue;
-        }
-
-        GVar.setLinkage(GlobalValue::ExternalLinkage);
-        GVar.setVisibility(GlobalValue::VisibilityTypes::DefaultVisibility);
-      }
-    }
-
     // TODO: Do we want to keep debug info to use for GDB/LLDB
     // interfaces for debugging jitted code?
     StripDebugInfo(*JitMod);

--- a/tests/cpu/CMakeLists.txt
+++ b/tests/cpu/CMakeLists.txt
@@ -22,6 +22,10 @@ function(CREATE_CPU_TEST exe check_source)
         ${NATIVE_OPT_FLAGS}
     )
 
+    target_link_options(${exe} PRIVATE
+        $<LINK_ONLY:-rdynamic>
+    )
+
     add_test(NAME ${exe} COMMAND ${LIT} -vv -D FILECHECK=${FILECHECK} ${check_source})
     set_tests_properties(${exe} PROPERTIES LABELS "cpu")
 endfunction()


### PR DESCRIPTION
- Do not change linkage and visibility in the original module's symbols
- Remove duplicate check for unresolved symbols in the LLVM IR
- Link consumer tests with `-rdynamic` (as we document)