### PR TITLE
Parallelize tests

### DIFF
--- a/.github/workflows/ci-build-test.yml
+++ b/.github/workflows/ci-build-test.yml
@@ -56,5 +56,5 @@ jobs:
       - name: Test
         run: |
           pushd build
-          ctest -T test --output-on-failure
+          ctest -j8 -T test --output-on-failure
           popd

--- a/include/proteus/Config.hpp
+++ b/include/proteus/Config.hpp
@@ -131,9 +131,12 @@ public:
   CodegenOption ProteusCodegen;
   bool ProteusTraceOutput;
   std::optional<const std::string> ProteusOptPipeline;
+  std::optional<const std::string> ProteusCacheDir;
 
 private:
-  Config() : ProteusOptPipeline(getEnvOrDefaultString("PROTEUS_OPT_PIPELINE")) {
+  Config()
+      : ProteusOptPipeline(getEnvOrDefaultString("PROTEUS_OPT_PIPELINE")),
+        ProteusCacheDir(getEnvOrDefaultString("PROTEUS_CACHE_DIR")) {
     ProteusUseStoredCache =
         getEnvOrDefaultBool("PROTEUS_USE_STORED_CACHE", true);
     ProteusSpecializeLaunchBounds =

--- a/include/proteus/JitStorageCache.hpp
+++ b/include/proteus/JitStorageCache.hpp
@@ -22,6 +22,7 @@
 #include <llvm/ADT/StringRef.h>
 
 #include "proteus/CompiledLibrary.hpp"
+#include "proteus/Config.hpp"
 #include "proteus/Hashing.hpp"
 #include "proteus/Utils.h"
 
@@ -36,7 +37,12 @@ using namespace llvm;
 // globals.
 class JitStorageCache {
 public:
-  JitStorageCache() { std::filesystem::create_directory(StorageDirectory); }
+  JitStorageCache()
+      : StorageDirectory(Config::get().ProteusCacheDir
+                             ? Config::get().ProteusCacheDir.value()
+                             : ".proteus") {
+    std::filesystem::create_directory(StorageDirectory);
+  }
 
   std::unique_ptr<CompiledLibrary> lookup(HashT &HashValue) {
     TIMESCOPE("object lookup");
@@ -90,7 +96,7 @@ public:
 private:
   uint64_t Hits = 0;
   uint64_t Accesses = 0;
-  const std::string StorageDirectory = ".proteus";
+  const std::string StorageDirectory;
 };
 
 } // namespace proteus

--- a/scripts/gitlab/ci-build-test.sh
+++ b/scripts/gitlab/ci-build-test.sh
@@ -74,39 +74,39 @@ fi
 
 # Test synchronous compilation (default) and kernel clone options.
 echo "### $(date) START TESTING SYNC COMPILATION KERNEL_CLONE cross-clone ###"
-PROTEUS_KERNEL_CLONE=cross-clone ctest -T test --output-on-failure
+PROTEUS_KERNEL_CLONE=cross-clone ctest -j8 -T test --output-on-failure
 echo "### $(date) END TESTING SYNC COMPILATION KERNEL_CLONE cross-clone ###"
 
 echo "### $(date) START TESTING SYNC COMPILATION KERNEL_CLONE link-clone-light ###"
-PROTEUS_KERNEL_CLONE=link-clone-light ctest -T test --output-on-failure
+PROTEUS_KERNEL_CLONE=link-clone-light ctest -j8 -T test --output-on-failure
 echo "### $(date) END TESTING SYNC COMPILATION KERNEL_CLONE link-clone-light ###"
 
 echo "### $(date) START TESTING SYNC COMPILATION KERNEL_CLONE link-clone-prune ###"
-PROTEUS_KERNEL_CLONE=link-clone-prune ctest -T test --output-on-failure
+PROTEUS_KERNEL_CLONE=link-clone-prune ctest -j8 -T test --output-on-failure
 echo "### $(date) END TESTING SYNC COMPILATION KERNEL_CLONE link-clone-prune ###"
 
 # Test asynchronous compilation.
 echo "### $(date) START TESTING (BLOCKING) ASYNC COMPILATION ###"
-PROTEUS_ASYNC_COMPILATION=1 PROTEUS_ASYNC_TEST_BLOCKING=1 ctest -T test --output-on-failure
+PROTEUS_ASYNC_COMPILATION=1 PROTEUS_ASYNC_TEST_BLOCKING=1 ctest -j8 -T test --output-on-failure
 echo "### $(date) END TESTING (BLOCKING) ASYNC COMPILATION ###"
 
 # Test also our faster, alternative to HIP RTC codegen.
 if [ "${CI_MACHINE}" == "tioga" ]; then
   echo "### $(date) START TESTING SYNC COMPILATION WITH PROTEUS CODEGEN SERIAL ###"
-  PROTEUS_CODEGEN=serial ctest -T test --output-on-failure
+  PROTEUS_CODEGEN=serial ctest -j8 -T test --output-on-failure
   echo "### $(date) END TESTING SYNC COMPILATION WITH PROTEUS HIP CODEGEN SERIAL ###"
 
   echo "### $(date) START TESTING (BLOCKING) ASYNC COMPILATION WITH PROTEUS CODEGEN SERIAL ###"
-  PROTEUS_ASYNC_COMPILATION=1 PROTEUS_ASYNC_TEST_BLOCKING=1 PROTEUS_CODEGEN=serial ctest -T test --output-on-failure
+  PROTEUS_ASYNC_COMPILATION=1 PROTEUS_ASYNC_TEST_BLOCKING=1 PROTEUS_CODEGEN=serial ctest -j8 -T test --output-on-failure
   echo "### $(date) END TESTING (BLOCKING) ASYNC COMPILATION WITH PROTEUS CODEGEN SERIAL ###"
 
   if [ "${PROTEUS_CI_ROCM_VERSION}" == "6.2.1" ] || [ "${PROTEUS_CI_ROCM_VERSION}" == "6.3.1" ];  then
     echo "### $(date) START TESTING SYNC COMPILATION WITH PROTEUS CODEGEN PARALLEL ###"
-    PROTEUS_CODEGEN=parallel ctest -T test --output-on-failure
+    PROTEUS_CODEGEN=parallel ctest -j8 -T test --output-on-failure
     echo "### $(date) END TESTING SYNC COMPILATION WITH PROTEUS HIP CODEGEN PARALLEL ###"
 
     echo "### $(date) START TESTING (BLOCKING) ASYNC COMPILATION WITH PROTEUS CODEGEN PARALLEL ###"
-    PROTEUS_ASYNC_COMPILATION=1 PROTEUS_ASYNC_TEST_BLOCKING=1 PROTEUS_CODEGEN=parallel ctest -T test --output-on-failure
+    PROTEUS_ASYNC_COMPILATION=1 PROTEUS_ASYNC_TEST_BLOCKING=1 PROTEUS_CODEGEN=parallel ctest -j8 -T test --output-on-failure
     echo "### $(date) END TESTING (BLOCKING) ASYNC COMPILATION WITH PROTEUS CODEGEN PARALLEL ###"
   fi
 fi

--- a/src/lib/JitEngine.cpp
+++ b/src/lib/JitEngine.cpp
@@ -41,7 +41,8 @@ JitEngine::JitEngine() {
                           << toString(Config::get().ProteusCodegen) << "\n";
   Logger::logs("proteus") << "PROTEUS_OPT_PIPELINE"
                           << Config::get().ProteusOptPipeline << "\n";
-
+  Logger::logs("proteus") << "PROTEUS_CACHE_DIR"
+                          << Config::get().ProteusCacheDir << "\n";
 #endif
 }
 

--- a/tests/cpu/CMakeLists.txt
+++ b/tests/cpu/CMakeLists.txt
@@ -30,6 +30,9 @@ file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/lit.cfg.py "
 import lit.formats
 import os
 import platform
+import tempfile
+import atexit
+import shutil
 
 config.name = 'LIT tests'
 config.test_format = lit.formats.ShTest(True)
@@ -37,10 +40,15 @@ config.environment = os.environ.copy()
 
 config.suffixes = ['.cpp']
 config.test_source_root = '${CMAKE_CURRENT_SOURCE_DIR}'
-config.test_exec_root = '${CMAKE_CURRENT_BINARY_DIR}'
+# Create a unique temp exec_root to avoid races on lit_test_times.txt
+exec_root = tempfile.mkdtemp(prefix='lit.tmp.', dir='${CMAKE_CURRENT_BINARY_DIR}')
+config.test_exec_root = exec_root
+atexit.register(lambda: shutil.rmtree(exec_root, ignore_errors=False))
+
 FILECHECK = lit_config.params['FILECHECK']
 config.substitutions.append(('%FILECHECK', FILECHECK))
 config.substitutions.append(('%target_arch', platform.machine()))
+config.substitutions.append(('%build', '${CMAKE_CURRENT_BINARY_DIR}'))
 "
 )
 

--- a/tests/cpu/custom_pipeline.cpp
+++ b/tests/cpu/custom_pipeline.cpp
@@ -1,17 +1,17 @@
 // clang-format off
-// RUN: rm -rf %t.$$.proteus
+// RUN: rm -rf "%t.$$.proteus"
 // RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_CODEGEN=serial PROTEUS_TRACE_OUTPUT=1 %build/custom_pipeline | %FILECHECK %s --check-prefixes=CHECK
-// RUN: rm -rf %t.$$.proteus
+// RUN: rm -rf "%t.$$.proteus"
 // RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 PROTEUS_CODEGEN=serial PROTEUS_TRACE_OUTPUT=1 PROTEUS_OPT_PIPELINE='default<O3>' %build/custom_pipeline | %FILECHECK %s --check-prefixes=CHECK,CHECK3
-// RUN: rm -rf %t.$$.proteus
+// RUN: rm -rf "%t.$$.proteus"
 // RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 PROTEUS_CODEGEN=serial PROTEUS_TRACE_OUTPUT=1 PROTEUS_OPT_PIPELINE='default<O2>' %build/custom_pipeline | %FILECHECK %s --check-prefixes=CHECK,CHECK2
-// RUN: rm -rf %t.$$.proteus
+// RUN: rm -rf "%t.$$.proteus"
 // RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 PROTEUS_CODEGEN=serial PROTEUS_TRACE_OUTPUT=1 PROTEUS_OPT_PIPELINE='default<O1>' %build/custom_pipeline | %FILECHECK %s --check-prefixes=CHECK,CHECK1
-// RUN: rm -rf %t.$$.proteus
+// RUN: rm -rf "%t.$$.proteus"
 // RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 PROTEUS_CODEGEN=serial PROTEUS_TRACE_OUTPUT=1 PROTEUS_OPT_PIPELINE='default<Os>' %build/custom_pipeline | %FILECHECK %s --check-prefixes=CHECK,CHECKs
-// RUN: rm -rf %t.$$.proteus
+// RUN: rm -rf "%t.$$.proteus"
 // RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 PROTEUS_CODEGEN=serial PROTEUS_TRACE_OUTPUT=1 PROTEUS_OPT_PIPELINE='default<Oz>' %build/custom_pipeline | %FILECHECK %s --check-prefixes=CHECK,CHECKz
-// RUN: rm -rf %t.$$.proteus
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <cstddef>

--- a/tests/cpu/custom_pipeline.cpp
+++ b/tests/cpu/custom_pipeline.cpp
@@ -1,17 +1,17 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_CODEGEN=serial PROTEUS_TRACE_OUTPUT=1 ./custom_pipeline | %FILECHECK %s --check-prefixes=CHECK
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_TRACE_OUTPUT=1 PROTEUS_CODEGEN=serial PROTEUS_TRACE_OUTPUT=1 PROTEUS_OPT_PIPELINE='default<O3>' ./custom_pipeline | %FILECHECK %s --check-prefixes=CHECK,CHECK3
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_TRACE_OUTPUT=1 PROTEUS_CODEGEN=serial PROTEUS_TRACE_OUTPUT=1 PROTEUS_OPT_PIPELINE='default<O2>' ./custom_pipeline | %FILECHECK %s --check-prefixes=CHECK,CHECK2
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_TRACE_OUTPUT=1 PROTEUS_CODEGEN=serial PROTEUS_TRACE_OUTPUT=1 PROTEUS_OPT_PIPELINE='default<O1>' ./custom_pipeline | %FILECHECK %s --check-prefixes=CHECK,CHECK1
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_TRACE_OUTPUT=1 PROTEUS_CODEGEN=serial PROTEUS_TRACE_OUTPUT=1 PROTEUS_OPT_PIPELINE='default<Os>' ./custom_pipeline | %FILECHECK %s --check-prefixes=CHECK,CHECKs
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_TRACE_OUTPUT=1 PROTEUS_CODEGEN=serial PROTEUS_TRACE_OUTPUT=1 PROTEUS_OPT_PIPELINE='default<Oz>' ./custom_pipeline | %FILECHECK %s --check-prefixes=CHECK,CHECKz
-// RUN: rm -rf .proteus
+// RUN: rm -rf %t.$$.proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_CODEGEN=serial PROTEUS_TRACE_OUTPUT=1 %build/custom_pipeline | %FILECHECK %s --check-prefixes=CHECK
+// RUN: rm -rf %t.$$.proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 PROTEUS_CODEGEN=serial PROTEUS_TRACE_OUTPUT=1 PROTEUS_OPT_PIPELINE='default<O3>' %build/custom_pipeline | %FILECHECK %s --check-prefixes=CHECK,CHECK3
+// RUN: rm -rf %t.$$.proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 PROTEUS_CODEGEN=serial PROTEUS_TRACE_OUTPUT=1 PROTEUS_OPT_PIPELINE='default<O2>' %build/custom_pipeline | %FILECHECK %s --check-prefixes=CHECK,CHECK2
+// RUN: rm -rf %t.$$.proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 PROTEUS_CODEGEN=serial PROTEUS_TRACE_OUTPUT=1 PROTEUS_OPT_PIPELINE='default<O1>' %build/custom_pipeline | %FILECHECK %s --check-prefixes=CHECK,CHECK1
+// RUN: rm -rf %t.$$.proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 PROTEUS_CODEGEN=serial PROTEUS_TRACE_OUTPUT=1 PROTEUS_OPT_PIPELINE='default<Os>' %build/custom_pipeline | %FILECHECK %s --check-prefixes=CHECK,CHECKs
+// RUN: rm -rf %t.$$.proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 PROTEUS_CODEGEN=serial PROTEUS_TRACE_OUTPUT=1 PROTEUS_OPT_PIPELINE='default<Oz>' %build/custom_pipeline | %FILECHECK %s --check-prefixes=CHECK,CHECKz
+// RUN: rm -rf %t.$$.proteus
 // clang-format on
 
 #include <cstddef>

--- a/tests/cpu/daxpy.cpp
+++ b/tests/cpu/daxpy.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_TRACE_OUTPUT=1 ./daxpy | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf %t.$$.proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/daxpy | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./daxpy | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/daxpy | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf %t.$$.proteus
 // clang-format on
 
 #include <cstddef>

--- a/tests/cpu/daxpy.cpp
+++ b/tests/cpu/daxpy.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf %t.$$.proteus
+// RUN: rm -rf "%t.$$.proteus"
 // RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/daxpy | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
 // RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/daxpy | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf %t.$$.proteus
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <cstddef>

--- a/tests/cpu/daxpy_annot_long.cpp
+++ b/tests/cpu/daxpy_annot_long.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_TRACE_OUTPUT=1 ./daxpy_annot_long | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf %t.$$.proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/daxpy_annot_long | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./daxpy_annot_long | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/daxpy_annot_long | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf %t.$$.proteus
 // clang-format on
 
 #include <cstddef>

--- a/tests/cpu/daxpy_annot_long.cpp
+++ b/tests/cpu/daxpy_annot_long.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf %t.$$.proteus
+// RUN: rm -rf "%t.$$.proteus"
 // RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/daxpy_annot_long | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
 // RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/daxpy_annot_long | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf %t.$$.proteus
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <cstddef>

--- a/tests/cpu/daxpy_annot_mix.cpp
+++ b/tests/cpu/daxpy_annot_mix.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_TRACE_OUTPUT=1 ./daxpy_annot_long | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf %t.$$.proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/daxpy_annot_long | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./daxpy_annot_long | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/daxpy_annot_long | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf %t.$$.proteus
 // clang-format on
 
 #include <cstddef>

--- a/tests/cpu/daxpy_annot_mix.cpp
+++ b/tests/cpu/daxpy_annot_mix.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf %t.$$.proteus
+// RUN: rm -rf "%t.$$.proteus"
 // RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/daxpy_annot_long | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
 // RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/daxpy_annot_long | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf %t.$$.proteus
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <cstddef>

--- a/tests/cpu/daxpy_api.cpp
+++ b/tests/cpu/daxpy_api.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf %t.$$.proteus
+// RUN: rm -rf "%t.$$.proteus"
 // RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/daxpy_api | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
 // RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/daxpy_api | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf %t.$$.proteus
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <cstddef>

--- a/tests/cpu/daxpy_api.cpp
+++ b/tests/cpu/daxpy_api.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_TRACE_OUTPUT=1 ./daxpy_api | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf %t.$$.proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/daxpy_api | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./daxpy_api | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/daxpy_api | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf %t.$$.proteus
 // clang-format on
 
 #include <cstddef>

--- a/tests/cpu/dynamic_jit_array.cpp
+++ b/tests/cpu/dynamic_jit_array.cpp
@@ -1,8 +1,9 @@
 // clang-format off
-// RUN: rm -rf %t.$$.proteus
+// RUN: rm -rf "%t.$$.proteus"
 // RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/dynamic_jit_array | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
 // RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/dynamic_jit_array | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <climits>

--- a/tests/cpu/dynamic_jit_array.cpp
+++ b/tests/cpu/dynamic_jit_array.cpp
@@ -1,8 +1,8 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_TRACE_OUTPUT=1 ./dynamic_jit_array | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf %t.$$.proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/dynamic_jit_array | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./dynamic_jit_array | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/dynamic_jit_array | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
 // clang-format on
 
 #include <climits>

--- a/tests/cpu/jit_struct.cpp
+++ b/tests/cpu/jit_struct.cpp
@@ -1,8 +1,8 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_TRACE_OUTPUT=1 ./jit_struct | %FILECHECK %s --check-prefixes=CHECK,CHECK-%target_arch,CHECK-FIRST
+// RUN: rm -rf %t.$$.proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/jit_struct | %FILECHECK %s --check-prefixes=CHECK,CHECK-%target_arch,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./jit_struct | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/jit_struct | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
 // clang-format on
 
 #include <climits>

--- a/tests/cpu/jit_struct.cpp
+++ b/tests/cpu/jit_struct.cpp
@@ -1,8 +1,9 @@
 // clang-format off
-// RUN: rm -rf %t.$$.proteus
+// RUN: rm -rf "%t.$$.proteus"
 // RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/jit_struct | %FILECHECK %s --check-prefixes=CHECK,CHECK-%target_arch,CHECK-FIRST
 // Second run uses the object cache.
 // RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/jit_struct | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <climits>

--- a/tests/cpu/lambda.cpp
+++ b/tests/cpu/lambda.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_TRACE_OUTPUT=1 ./lambda | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf %t.$$.proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/lambda | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./lambda | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/lambda | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf %t.$$.proteus
 // clang-format on
 
 #include <iostream>

--- a/tests/cpu/lambda.cpp
+++ b/tests/cpu/lambda.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf %t.$$.proteus
+// RUN: rm -rf "%t.$$.proteus"
 // RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/lambda | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
 // RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/lambda | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf %t.$$.proteus
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <iostream>

--- a/tests/cpu/lambda_def.cpp
+++ b/tests/cpu/lambda_def.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_TRACE_OUTPUT=1 ./lambda_def | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf %t.$$.proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/lambda_def | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./lambda_def | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/lambda_def | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf %t.$$.proteus
 // clang-format on
 
 #include <cstdio>

--- a/tests/cpu/lambda_def.cpp
+++ b/tests/cpu/lambda_def.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf %t.$$.proteus
+// RUN: rm -rf "%t.$$.proteus"
 // RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/lambda_def | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
 // RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/lambda_def | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf %t.$$.proteus
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <cstdio>

--- a/tests/cpu/lambda_multiple.cpp
+++ b/tests/cpu/lambda_multiple.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_TRACE_OUTPUT=1 ./lambda_multiple | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf %t.$$.proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/lambda_multiple | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./lambda_multiple | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/lambda_multiple | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf %t.$$.proteus
 // clang-format on
 
 #include <iostream>

--- a/tests/cpu/lambda_multiple.cpp
+++ b/tests/cpu/lambda_multiple.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf %t.$$.proteus
+// RUN: rm -rf "%t.$$.proteus"
 // RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/lambda_multiple | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
 // RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/lambda_multiple | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf %t.$$.proteus
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <iostream>

--- a/tests/cpu/lambda_multiple_api.cpp
+++ b/tests/cpu/lambda_multiple_api.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_TRACE_OUTPUT=1 ./lambda_multiple_api | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf %t.$$.proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/lambda_multiple_api | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./lambda_multiple_api | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/lambda_multiple_api | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf %t.$$.proteus
 // clang-format on
 
 #include <cstdio>

--- a/tests/cpu/lambda_multiple_api.cpp
+++ b/tests/cpu/lambda_multiple_api.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf %t.$$.proteus
+// RUN: rm -rf "%t.$$.proteus"
 // RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/lambda_multiple_api | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
 // RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/lambda_multiple_api | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf %t.$$.proteus
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <cstdio>

--- a/tests/cpu/types.cpp
+++ b/tests/cpu/types.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf %t.$$.proteus
+// RUN: rm -rf "%t.$$.proteus"
 // RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/types | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
 // RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/types | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf %t.$$.proteus
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <cstdlib>

--- a/tests/cpu/types.cpp
+++ b/tests/cpu/types.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_TRACE_OUTPUT=1 ./types | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf %t.$$.proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/types | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./types | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/types | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf %t.$$.proteus
 // clang-format on
 
 #include <cstdlib>

--- a/tests/cpu/types_api.cpp
+++ b/tests/cpu/types_api.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_TRACE_OUTPUT=1 ./types_api | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf %t.$$.proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/types_api | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./types_api | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/types_api | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf %t.$$.proteus
 // clang-format on
 
 #include <cstdlib>

--- a/tests/cpu/types_api.cpp
+++ b/tests/cpu/types_api.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf %t.$$.proteus
+// RUN: rm -rf "%t.$$.proteus"
 // RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/types_api | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
 // RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/types_api | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf %t.$$.proteus
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <cstdlib>

--- a/tests/cpu/types_jit_array.cpp
+++ b/tests/cpu/types_jit_array.cpp
@@ -1,8 +1,8 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_TRACE_OUTPUT=1 ./types_jit_array | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf %t.$$.proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/types_jit_array | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./types_jit_array | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/types_jit_array | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
 // clang-format on
 
 #include <climits>

--- a/tests/cpu/types_jit_array.cpp
+++ b/tests/cpu/types_jit_array.cpp
@@ -1,8 +1,9 @@
 // clang-format off
-// RUN: rm -rf %t.$$.proteus
+// RUN: rm -rf "%t.$$.proteus"
 // RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/types_jit_array | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
 // RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/types_jit_array | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <climits>

--- a/tests/frontend/cpu/CMakeLists.txt
+++ b/tests/frontend/cpu/CMakeLists.txt
@@ -26,6 +26,9 @@ endfunction()
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/lit.cfg.py "
 import lit.formats
 import os
+import tempfile
+import atexit
+import shutil
 
 config.name = 'LIT tests'
 config.test_format = lit.formats.ShTest(True)
@@ -33,9 +36,14 @@ config.environment = os.environ.copy()
 
 config.suffixes = ['.cpp']
 config.test_source_root = '${CMAKE_CURRENT_SOURCE_DIR}'
-config.test_exec_root = '${CMAKE_CURRENT_BINARY_DIR}'
+# Create a unique temp exec_root to avoid races on lit_test_times.txt
+exec_root = tempfile.mkdtemp(prefix='lit.tmp.', dir='${CMAKE_CURRENT_BINARY_DIR}')
+config.test_exec_root = exec_root
+atexit.register(lambda: shutil.rmtree(exec_root, ignore_errors=False))
+
 FILECHECK = lit_config.params['FILECHECK']
 config.substitutions.append(('%FILECHECK', FILECHECK))
+config.substitutions.append(('%build', '${CMAKE_CURRENT_BINARY_DIR}'))
 "
 )
 

--- a/tests/frontend/cpu/add_vectors.cpp
+++ b/tests/frontend/cpu/add_vectors.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: ./add_vectors | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/add_vectors | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./add_vectors | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/add_vectors | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <proteus/JitFrontend.hpp>

--- a/tests/frontend/cpu/add_vectors_runconst.cpp
+++ b/tests/frontend/cpu/add_vectors_runconst.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: ./add_vectors_runconst | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/add_vectors_runconst | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./add_vectors_runconst | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/add_vectors_runconst | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <proteus/JitFrontend.hpp>

--- a/tests/frontend/cpu/cpp_instantiate.cpp
+++ b/tests/frontend/cpu/cpp_instantiate.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: ./cpp_instantiate | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/cpp_instantiate | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./cpp_instantiate | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/cpp_instantiate | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <iostream>

--- a/tests/frontend/cpu/cpp_same_symbol.cpp
+++ b/tests/frontend/cpu/cpp_same_symbol.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: ./cpp_same_symbol | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/cpp_same_symbol | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./cpp_same_symbol | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/cpp_same_symbol | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 // Tests that kernels with the same symbol from different modules are correctly

--- a/tests/frontend/cpu/cpp_source.cpp
+++ b/tests/frontend/cpu/cpp_source.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: ./cpp_source | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/cpp_source | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./cpp_source | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/cpp_source | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <iostream>

--- a/tests/frontend/cpu/cpp_store_handle.cpp
+++ b/tests/frontend/cpu/cpp_store_handle.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: ./cpp_store_handle | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/cpp_store_handle | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./cpp_store_handle | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/cpp_store_handle | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include "proteus/CppJitModule.hpp"

--- a/tests/frontend/cpu/external_call.cpp
+++ b/tests/frontend/cpu/external_call.cpp
@@ -1,8 +1,10 @@
-// RUN: rm -rf .proteus
-// RUN: ./external_call | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// clang-format off
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/external_call | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./external_call | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/external_call | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
+// clang-format on
 
 #include <iostream>
 

--- a/tests/frontend/cpu/for.cpp
+++ b/tests/frontend/cpu/for.cpp
@@ -1,8 +1,10 @@
-// RUN: rm -rf .proteus
-// RUN: ./for | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// clang-format off
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/for | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./for | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/for | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
+// clang-format on
 
 #include <iostream>
 

--- a/tests/frontend/cpu/if.cpp
+++ b/tests/frontend/cpu/if.cpp
@@ -1,8 +1,10 @@
-// RUN: rm -rf .proteus
-// RUN: ./if | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// clang-format off
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/if | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./if | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/if | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
+// clang-format on
 
 #include <iostream>
 

--- a/tests/frontend/cpu/internal_call.cpp
+++ b/tests/frontend/cpu/internal_call.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: ./internal_call | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/internal_call | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./internal_call | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/internal_call | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <proteus/JitFrontend.hpp>

--- a/tests/frontend/cpu/loopnest_1d.cpp
+++ b/tests/frontend/cpu/loopnest_1d.cpp
@@ -1,6 +1,8 @@
-// RUN: rm -rf .proteus
-// RUN: ./loopnest_1d | %FILECHECK %s --check-prefixes=CHECK
-// RUN: rm -rf .proteus
+// clang-format off
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/loopnest_1d | %FILECHECK %s --check-prefixes=CHECK
+// RUN: rm -rf "%t.$$.proteus"
+// clang-format on
 
 #include <iostream>
 #include <proteus/JitFrontend.hpp>

--- a/tests/frontend/cpu/loopnest_3d.cpp
+++ b/tests/frontend/cpu/loopnest_3d.cpp
@@ -1,6 +1,8 @@
-// RUN: rm -rf .proteus
-// RUN: ./loopnest_3d | %FILECHECK %s --check-prefixes=CHECK
-// RUN: rm -rf .proteus
+// clang-format off
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/loopnest_3d | %FILECHECK %s --check-prefixes=CHECK
+// RUN: rm -rf "%t.$$.proteus"
+// clang-format on
 
 #include <iostream>
 #include <proteus/JitFrontend.hpp>

--- a/tests/frontend/cpu/min.cpp
+++ b/tests/frontend/cpu/min.cpp
@@ -1,6 +1,8 @@
-// RUN: rm -rf .proteus
-// RUN: ./min | %FILECHECK %s --check-prefixes=CHECK
-// RUN: rm -rf .proteus
+// clang-format off
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/min | %FILECHECK %s --check-prefixes=CHECK
+// RUN: rm -rf "%t.$$.proteus"
+// clang-format on
 
 #include <iostream>
 

--- a/tests/frontend/cpu/multi_module.cpp
+++ b/tests/frontend/cpu/multi_module.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: ./multi_module | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/multi_module | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./multi_module | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/multi_module | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <proteus/JitFrontend.hpp>

--- a/tests/frontend/cpu/operators.cpp
+++ b/tests/frontend/cpu/operators.cpp
@@ -1,8 +1,10 @@
-// RUN: rm -rf .proteus
-// RUN: ./operators | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// clang-format off
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/operators | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./operators | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/operators | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
+// clang-format on
 
 #include <iostream>
 

--- a/tests/frontend/cpu/tiled_matmul.cpp
+++ b/tests/frontend/cpu/tiled_matmul.cpp
@@ -1,6 +1,8 @@
-// RUN: rm -rf .proteus
-// RUN: ./tiled_matmul 16 3 4 5 | %FILECHECK %s --check-prefixes=CHECK
-// RUN: rm -rf .proteus
+// clang-format off
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/tiled_matmul 16 3 4 5 | %FILECHECK %s --check-prefixes=CHECK
+// RUN: rm -rf "%t.$$.proteus"
+// clang-format on
 
 #include <cstdlib>
 #include <iostream>

--- a/tests/frontend/cpu/tiled_transpose.cpp
+++ b/tests/frontend/cpu/tiled_transpose.cpp
@@ -1,8 +1,10 @@
-// RUN: rm -rf .proteus
-// RUN: ./tiled_transpose 4 4 2 | %FILECHECK %s --check-prefixes=FIRST
-// RUN: rm -rf .proteus
-// RUN: ./tiled_transpose 5 4 3 | %FILECHECK %s --check-prefixes=SECOND
-// RUN: rm -rf .proteus
+// clang-format off
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/tiled_transpose 4 4 2 | %FILECHECK %s --check-prefixes=FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/tiled_transpose 5 4 3 | %FILECHECK %s --check-prefixes=SECOND
+// RUN: rm -rf "%t.$$.proteus"
+// clang-format on
 
 #include <cstdlib>
 #include <iostream>

--- a/tests/frontend/gpu/CMakeLists.txt
+++ b/tests/frontend/gpu/CMakeLists.txt
@@ -33,6 +33,9 @@ endfunction()
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/lit.cfg.py "
 import lit.formats
 import os
+import tempfile
+import atexit
+import shutil
 
 config.name = 'LIT tests'
 config.test_format = lit.formats.ShTest(True)
@@ -40,11 +43,16 @@ config.environment = os.environ.copy()
 
 config.suffixes = ['.cpp']
 config.test_source_root = '${CMAKE_CURRENT_SOURCE_DIR}'
-config.test_exec_root = '${CMAKE_CURRENT_BINARY_DIR}'
+# Create a unique temp exec_root to avoid races on lit_test_times.txt
+exec_root = tempfile.mkdtemp(prefix='lit.tmp.', dir='${CMAKE_CURRENT_BINARY_DIR}')
+config.test_exec_root = exec_root
+atexit.register(lambda: shutil.rmtree(exec_root, ignore_errors=False))
+
 ext = lit_config.params['EXT']
 FILECHECK = lit_config.params['FILECHECK']
 config.substitutions.append(('%ext', ext))
 config.substitutions.append(('%FILECHECK', FILECHECK))
+config.substitutions.append(('%build', '${CMAKE_CURRENT_BINARY_DIR}'))
 "
 )
 

--- a/tests/frontend/gpu/adam.cpp
+++ b/tests/frontend/gpu/adam.cpp
@@ -1,11 +1,11 @@
 // NOLINTBEGIN
 
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: ./adam.%ext 10000 200 100 | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/adam.%ext 10000 200 100 | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./adam.%ext 10000 200 100 | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/adam.%ext 10000 200 100 | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <proteus/Frontend/Builtins.hpp>

--- a/tests/frontend/gpu/adam_runconst.cpp
+++ b/tests/frontend/gpu/adam_runconst.cpp
@@ -1,11 +1,11 @@
 // NOLINTBEGIN
 
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: ./adam_runconst.%ext 10000 200 100 | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/adam_runconst.%ext 10000 200 100 | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./adam_runconst.%ext 10000 200 100 | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/adam_runconst.%ext 10000 200 100 | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <proteus/Frontend/Builtins.hpp>

--- a/tests/frontend/gpu/add_vectors.cpp
+++ b/tests/frontend/gpu/add_vectors.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: ./add_vectors.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/add_vectors.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./add_vectors.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/add_vectors.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <proteus/Frontend/Builtins.hpp>

--- a/tests/frontend/gpu/add_vectors_runconst.cpp
+++ b/tests/frontend/gpu/add_vectors_runconst.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: ./add_vectors_runconst.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/add_vectors_runconst.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./add_vectors_runconst.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/add_vectors_runconst.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <proteus/Frontend/Builtins.hpp>

--- a/tests/frontend/gpu/cpp_adam.cpp
+++ b/tests/frontend/gpu/cpp_adam.cpp
@@ -1,11 +1,11 @@
 // NOLINTBEGIN
 
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: ./cpp_adam.%ext 10000 200 100 | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/cpp_adam.%ext 10000 200 100 | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./cpp_adam.%ext 10000 200 100 | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/cpp_adam.%ext 10000 200 100 | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <proteus/CppJitModule.hpp>

--- a/tests/frontend/gpu/cpp_instantiate.cpp
+++ b/tests/frontend/gpu/cpp_instantiate.cpp
@@ -1,8 +1,8 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: ./cpp_instantiate.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
-// RUN: ./cpp_instantiate.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/cpp_instantiate.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/cpp_instantiate.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include "proteus/CppJitModule.hpp"

--- a/tests/frontend/gpu/cpp_same_symbol.cpp
+++ b/tests/frontend/gpu/cpp_same_symbol.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: ./cpp_same_symbol.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/cpp_same_symbol.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./cpp_same_symbol.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/cpp_same_symbol.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 // Tests that kernels with the same symbol from different modules are correctly

--- a/tests/frontend/gpu/cpp_source.cpp
+++ b/tests/frontend/gpu/cpp_source.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: ./cpp_source.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/cpp_source.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./cpp_source.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/cpp_source.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include "proteus/CppJitModule.hpp"

--- a/tests/frontend/gpu/cpp_store_handle.cpp
+++ b/tests/frontend/gpu/cpp_store_handle.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: ./cpp_store_handle.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/cpp_store_handle.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./cpp_store_handle.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/cpp_store_handle.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include "proteus/CppJitModule.hpp"

--- a/tests/frontend/gpu/floydwarshall.cpp
+++ b/tests/frontend/gpu/floydwarshall.cpp
@@ -1,10 +1,10 @@
 // NOLINTBEGIN
 
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: ./floydwarshall.%ext 1024 100 16 | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
-// RUN: ./floydwarshall.%ext 1024 100 16 | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/floydwarshall.%ext 1024 100 16 | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/floydwarshall.%ext 1024 100 16 | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <proteus/Frontend/Builtins.hpp>

--- a/tests/frontend/gpu/for.cpp
+++ b/tests/frontend/gpu/for.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: ./for.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/for.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./for.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/for.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <iostream>

--- a/tests/frontend/gpu/if.cpp
+++ b/tests/frontend/gpu/if.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: ./if.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/if.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./if.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/if.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <iostream>

--- a/tests/frontend/gpu/internal_call.cpp
+++ b/tests/frontend/gpu/internal_call.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: ./internal_call.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/internal_call.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./internal_call.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/internal_call.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <proteus/Frontend/Builtins.hpp>

--- a/tests/frontend/gpu/kernel_2d.cpp
+++ b/tests/frontend/gpu/kernel_2d.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: ./kernel_2d.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/kernel_2d.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./kernel_2d.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/kernel_2d.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <proteus/Frontend/Builtins.hpp>

--- a/tests/frontend/gpu/kernel_3d.cpp
+++ b/tests/frontend/gpu/kernel_3d.cpp
@@ -1,8 +1,8 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: ./kernel_3d.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
-// RUN: ./kernel_3d.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/kernel_3d.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/kernel_3d.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <proteus/Frontend/Builtins.hpp>

--- a/tests/frontend/gpu/multi_module.cpp
+++ b/tests/frontend/gpu/multi_module.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: ./multi_module.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/multi_module.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./multi_module.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/multi_module.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <proteus/Frontend/Builtins.hpp>

--- a/tests/frontend/gpu/operators.cpp
+++ b/tests/frontend/gpu/operators.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: ./operators.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/operators.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./operators.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/operators.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <iostream>

--- a/tests/frontend/host_device/CMakeLists.txt
+++ b/tests/frontend/host_device/CMakeLists.txt
@@ -1,6 +1,9 @@
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/lit.cfg.py "
 import lit.formats
 import os
+import tempfile
+import atexit
+import shutil
 
 config.name = 'LIT tests'
 config.test_format = lit.formats.ShTest(True)
@@ -8,9 +11,14 @@ config.environment = os.environ.copy()
 
 config.suffixes = ['.cpp']
 config.test_source_root = '${CMAKE_CURRENT_SOURCE_DIR}'
-config.test_exec_root = '${CMAKE_CURRENT_BINARY_DIR}'
+# Create a unique temp exec_root to avoid races on lit_test_times.txt
+exec_root = tempfile.mkdtemp(prefix='lit.tmp.', dir='${CMAKE_CURRENT_BINARY_DIR}')
+config.test_exec_root = exec_root
+atexit.register(lambda: shutil.rmtree(exec_root, ignore_errors=False))
+
 FILECHECK = lit_config.params['FILECHECK']
 config.substitutions.append(('%FILECHECK', FILECHECK))
+config.substitutions.append(('%build', '${CMAKE_CURRENT_BINARY_DIR}'))
 "
 )
 

--- a/tests/frontend/host_device/cpp_host_device.cpp
+++ b/tests/frontend/host_device/cpp_host_device.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: ./cpp_host_device | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/cpp_host_device | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./cpp_host_device | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/cpp_host_device | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include "proteus/CppJitModule.hpp"

--- a/tests/gpu/CMakeLists.txt
+++ b/tests/gpu/CMakeLists.txt
@@ -217,6 +217,9 @@ endif()
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/lit.cfg.py "
 import lit.formats
 import os
+import tempfile
+import atexit
+import shutil
 
 config.name = 'LIT tests'
 config.test_format = lit.formats.ShTest(True)
@@ -224,11 +227,16 @@ config.environment = os.environ.copy()
 
 config.suffixes = ['.cpp']
 config.test_source_root = '${CMAKE_CURRENT_SOURCE_DIR}'
-config.test_exec_root = '${CMAKE_CURRENT_BINARY_DIR}'
+# Create a unique temp exec_root to avoid races on lit_test_times.txt
+exec_root = tempfile.mkdtemp(prefix='lit.tmp.', dir='${CMAKE_CURRENT_BINARY_DIR}')
+config.test_exec_root = exec_root
+atexit.register(lambda: shutil.rmtree(exec_root, ignore_errors=False))
+
 ext = lit_config.params['EXT']
 FILECHECK = lit_config.params['FILECHECK']
 config.substitutions.append(('%ext', ext))
 config.substitutions.append(('%FILECHECK', FILECHECK))
+config.substitutions.append(('%build', '${CMAKE_CURRENT_BINARY_DIR}'))
 "
 )
 

--- a/tests/gpu/alias_func.cpp
+++ b/tests/gpu/alias_func.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: ./alias_func.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/alias_func.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./alias_func.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/alias_func.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <cstdio>

--- a/tests/gpu/alias_gvar.cpp
+++ b/tests/gpu/alias_gvar.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_TRACE_OUTPUT=1 ./alias_gvar.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/alias_gvar.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./alias_gvar.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/alias_gvar.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include "gpu_common.h"

--- a/tests/gpu/block_grid_dim_1d.cpp
+++ b/tests/gpu/block_grid_dim_1d.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_TRACE_OUTPUT=1 ./block_grid_dim_1d.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/block_grid_dim_1d.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./block_grid_dim_1d.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/block_grid_dim_1d.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <climits>

--- a/tests/gpu/block_grid_dim_2d.cpp
+++ b/tests/gpu/block_grid_dim_2d.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_TRACE_OUTPUT=1 ./block_grid_dim_2d.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/block_grid_dim_2d.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./block_grid_dim_2d.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/block_grid_dim_2d.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <climits>

--- a/tests/gpu/block_grid_dim_3d.cpp
+++ b/tests/gpu/block_grid_dim_3d.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_TRACE_OUTPUT=1 ./block_grid_dim_3d.%ext |  %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/block_grid_dim_3d.%ext |  %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./block_grid_dim_3d.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/block_grid_dim_3d.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <climits>

--- a/tests/gpu/builtin_globals.cpp
+++ b/tests/gpu/builtin_globals.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_TRACE_OUTPUT=1 ./builtin_globals.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/builtin_globals.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./builtin_globals.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/builtin_globals.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <climits>

--- a/tests/gpu/daxpy.cpp
+++ b/tests/gpu/daxpy.cpp
@@ -1,8 +1,8 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_TRACE_OUTPUT=1 ./daxpy.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
-// ./daxpy.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/daxpy.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/daxpy.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <cstddef>

--- a/tests/gpu/daxpy_api.cpp
+++ b/tests/gpu/daxpy_api.cpp
@@ -1,8 +1,8 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_TRACE_OUTPUT=1 ./daxpy_api.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
-// ./daxpy_api.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/daxpy_api.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/daxpy_api.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <cstddef>

--- a/tests/gpu/dynamic_jit_array.cpp
+++ b/tests/gpu/dynamic_jit_array.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_TRACE_OUTPUT=1 ./dynamic_jit_array.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/dynamic_jit_array.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./dynamic_jit_array.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/dynamic_jit_array.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <climits>

--- a/tests/gpu/enable_disable.cpp
+++ b/tests/gpu/enable_disable.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: ./enable_disable.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/enable_disable.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./enable_disable.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/enable_disable.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <climits>

--- a/tests/gpu/file1_kernel.cpp
+++ b/tests/gpu/file1_kernel.cpp
@@ -1,8 +1,11 @@
-// RUN: rm -rf .proteus
-// RUN: ./multi_file.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// clang-format off
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/multi_file.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./multi_file.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/multi_file.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
+// clang-format on
+
 #include <climits>
 #include <cstdio>
 

--- a/tests/gpu/file1_kernel_launcher.cpp
+++ b/tests/gpu/file1_kernel_launcher.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: ./multi_file_launcher.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/multi_file_launcher.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./multi_file_launcher.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/multi_file_launcher.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 #include <climits>
 #include <cstdio>

--- a/tests/gpu/indirect_fallthrough.cpp
+++ b/tests/gpu/indirect_fallthrough.cpp
@@ -1,7 +1,7 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: ./indirect_fallthrough.%ext | %FILECHECK %s --check-prefixes=CHECK
-// RUN: rm -rf .proteus
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/indirect_fallthrough.%ext | %FILECHECK %s --check-prefixes=CHECK
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <climits>

--- a/tests/gpu/indirect_launcher.cpp
+++ b/tests/gpu/indirect_launcher.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: ./indirect_launcher.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/indirect_launcher.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./indirect_launcher.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/indirect_launcher.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <climits>

--- a/tests/gpu/indirect_launcher_arg.cpp
+++ b/tests/gpu/indirect_launcher_arg.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_TRACE_OUTPUT=1 ./indirect_launcher_arg.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/indirect_launcher_arg.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./indirect_launcher_arg.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/indirect_launcher_arg.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <climits>

--- a/tests/gpu/indirect_launcher_arg_api.cpp
+++ b/tests/gpu/indirect_launcher_arg_api.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_TRACE_OUTPUT=1 ./indirect_launcher_arg_api.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/indirect_launcher_arg_api.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./indirect_launcher_arg_api.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/indirect_launcher_arg_api.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <climits>

--- a/tests/gpu/indirect_launcher_multi.cpp
+++ b/tests/gpu/indirect_launcher_multi.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: ./indirect_launcher_multi.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/indirect_launcher_multi.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./indirect_launcher_multi.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/indirect_launcher_multi.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <climits>

--- a/tests/gpu/indirect_launcher_multi_arg.cpp
+++ b/tests/gpu/indirect_launcher_multi_arg.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: ./indirect_launcher_multi_arg.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/indirect_launcher_multi_arg.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./indirect_launcher_multi_arg.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/indirect_launcher_multi_arg.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <climits>

--- a/tests/gpu/indirect_launcher_multi_arg_api.cpp
+++ b/tests/gpu/indirect_launcher_multi_arg_api.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: ./indirect_launcher_multi_arg_api.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/indirect_launcher_multi_arg_api.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./indirect_launcher_multi_arg_api.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/indirect_launcher_multi_arg_api.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <climits>

--- a/tests/gpu/indirect_launcher_tpl_multi.cpp
+++ b/tests/gpu/indirect_launcher_tpl_multi.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: ./indirect_launcher_tpl_multi.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/indirect_launcher_tpl_multi.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./indirect_launcher_tpl_multi.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/indirect_launcher_tpl_multi.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <climits>

--- a/tests/gpu/indirect_launcher_tpl_multi_arg.cpp
+++ b/tests/gpu/indirect_launcher_tpl_multi_arg.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_TRACE_OUTPUT=1 ./indirect_launcher_tpl_multi_arg.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/indirect_launcher_tpl_multi_arg.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./indirect_launcher_tpl_multi_arg.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/indirect_launcher_tpl_multi_arg.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <climits>

--- a/tests/gpu/indirect_launcher_tpl_multi_arg_api.cpp
+++ b/tests/gpu/indirect_launcher_tpl_multi_arg_api.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_TRACE_OUTPUT=1 ./indirect_launcher_tpl_multi_arg_api.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/indirect_launcher_tpl_multi_arg_api.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./indirect_launcher_tpl_multi_arg_api.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/indirect_launcher_tpl_multi_arg_api.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <climits>

--- a/tests/gpu/jit_struct.cpp
+++ b/tests/gpu/jit_struct.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_TRACE_OUTPUT=1 ./jit_struct.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/jit_struct.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./jit_struct.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/jit_struct.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <climits>

--- a/tests/gpu/kernel.cpp
+++ b/tests/gpu/kernel.cpp
@@ -1,10 +1,11 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: ./kernel.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/kernel.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./kernel.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/kernel.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
+
 #include <climits>
 #include <cstdio>
 

--- a/tests/gpu/kernel_args.cpp
+++ b/tests/gpu/kernel_args.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_TRACE_OUTPUT=1 ./kernel_args.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/kernel_args.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./kernel_args.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/kernel_args.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 #include <climits>
 #include <cstdio>

--- a/tests/gpu/kernel_args_annot_long.cpp
+++ b/tests/gpu/kernel_args_annot_long.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_TRACE_OUTPUT=1 ./kernel_args_annot_long.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/kernel_args_annot_long.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./kernel_args_annot_long.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/kernel_args_annot_long.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 #include <climits>
 #include <cstdio>

--- a/tests/gpu/kernel_args_annot_mix.cpp
+++ b/tests/gpu/kernel_args_annot_mix.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_TRACE_OUTPUT=1 ./kernel_args_annot_mix.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/kernel_args_annot_mix.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./kernel_args_annot_mix.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/kernel_args_annot_mix.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 #include <climits>
 #include <cstdio>

--- a/tests/gpu/kernel_args_api.cpp
+++ b/tests/gpu/kernel_args_api.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_TRACE_OUTPUT=1 ./kernel_args_api.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/kernel_args_api.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./kernel_args_api.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/kernel_args_api.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 #include <climits>
 #include <cstdio>

--- a/tests/gpu/kernel_cache.cpp
+++ b/tests/gpu/kernel_cache.cpp
@@ -1,8 +1,11 @@
-// RUN: rm -rf .proteus
-// RUN: ./kernel_cache.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// clang-format off
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/kernel_cache.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./kernel_cache.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/kernel_cache.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
+// clang-format on
+
 #include <climits>
 #include <cstdio>
 

--- a/tests/gpu/kernel_calls_func.cpp
+++ b/tests/gpu/kernel_calls_func.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: ./kernel_calls_func.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/kernel_calls_func.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./kernel_calls_func.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/kernel_calls_func.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include "gpu_common.h"

--- a/tests/gpu/kernel_calls_func_api.cpp
+++ b/tests/gpu/kernel_calls_func_api.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: ./kernel_calls_func.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/kernel_calls_func.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./kernel_calls_func.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/kernel_calls_func.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include "gpu_common.h"

--- a/tests/gpu/kernel_calls_func_lib.cpp
+++ b/tests/gpu/kernel_calls_func_lib.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_TRACE_OUTPUT=1 ./kernel_calls_func_lib.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/kernel_calls_func_lib.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./kernel_calls_func_lib.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/kernel_calls_func_lib.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include "gpu_common.h"

--- a/tests/gpu/kernel_calls_func_lib_api.cpp
+++ b/tests/gpu/kernel_calls_func_lib_api.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_TRACE_OUTPUT=1 ./kernel_calls_func_lib_api.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/kernel_calls_func_lib_api.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./kernel_calls_func_lib_api.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/kernel_calls_func_lib_api.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include "gpu_common.h"

--- a/tests/gpu/kernel_calls_indirect.cpp
+++ b/tests/gpu/kernel_calls_indirect.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: ./kernel_calls_indirect.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/kernel_calls_indirect.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./kernel_calls_indirect.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/kernel_calls_indirect.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include "gpu_common.h"

--- a/tests/gpu/kernel_host_device_jit.cpp
+++ b/tests/gpu/kernel_host_device_jit.cpp
@@ -1,7 +1,7 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_TRACE_OUTPUT=1 ./kernel_host_device_jit.%ext | %FILECHECK %s --check-prefixes=CHECK
-// RUN: rm -rf .proteus
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/kernel_host_device_jit.%ext | %FILECHECK %s --check-prefixes=CHECK
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 #include <climits>
 #include <cstdio>

--- a/tests/gpu/kernel_host_device_jit_api.cpp
+++ b/tests/gpu/kernel_host_device_jit_api.cpp
@@ -1,7 +1,7 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_TRACE_OUTPUT=1 ./kernel_host_device_jit_api.%ext | %FILECHECK %s --check-prefixes=CHECK
-// RUN: rm -rf .proteus
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/kernel_host_device_jit_api.%ext | %FILECHECK %s --check-prefixes=CHECK
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <climits>

--- a/tests/gpu/kernel_host_jit.cpp
+++ b/tests/gpu/kernel_host_jit.cpp
@@ -1,6 +1,9 @@
-// RUN: rm -rf .proteus
-// RUN: ./kernel_host_jit.%ext | %FILECHECK %s --check-prefixes=CHECK
-// RUN: rm -rf .proteus
+// clang-format off
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/kernel_host_jit.%ext | %FILECHECK %s --check-prefixes=CHECK
+// RUN: rm -rf "%t.$$.proteus"
+// clang-format on
+
 #include <climits>
 #include <cstdio>
 

--- a/tests/gpu/kernel_launch_exception.cpp
+++ b/tests/gpu/kernel_launch_exception.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: ./kernel_launch_exception.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/kernel_launch_exception.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./kernel_launch_exception.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/kernel_launch_exception.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <climits>

--- a/tests/gpu/kernel_launches.cpp
+++ b/tests/gpu/kernel_launches.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: ./kernel_launches.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/kernel_launches.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./kernel_launches.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/kernel_launches.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 #include <climits>
 #include <cstdio>

--- a/tests/gpu/kernel_launches_args.cpp
+++ b/tests/gpu/kernel_launches_args.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: ./kernel_launches_args.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/kernel_launches_args.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./kernel_launches_args.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/kernel_launches_args.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 #include <climits>
 #include <cstdio>

--- a/tests/gpu/kernel_pass_pipeline.cpp
+++ b/tests/gpu/kernel_pass_pipeline.cpp
@@ -1,17 +1,17 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_CODEGEN=serial PROTEUS_TRACE_OUTPUT=1 ./kernel_pass_pipeline.%ext | %FILECHECK %s --check-prefixes=CHECK
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_TRACE_OUTPUT=1 PROTEUS_CODEGEN=serial PROTEUS_TRACE_OUTPUT=1 PROTEUS_OPT_PIPELINE='default<O3>' ./kernel_pass_pipeline.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK3
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_TRACE_OUTPUT=1 PROTEUS_CODEGEN=serial PROTEUS_TRACE_OUTPUT=1 PROTEUS_OPT_PIPELINE='default<O2>' ./kernel_pass_pipeline.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK2
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_TRACE_OUTPUT=1 PROTEUS_CODEGEN=serial PROTEUS_TRACE_OUTPUT=1 PROTEUS_OPT_PIPELINE='default<O1>' ./kernel_pass_pipeline.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK1
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_TRACE_OUTPUT=1 PROTEUS_CODEGEN=serial PROTEUS_TRACE_OUTPUT=1 PROTEUS_OPT_PIPELINE='default<Os>' ./kernel_pass_pipeline.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECKs
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_TRACE_OUTPUT=1 PROTEUS_CODEGEN=serial PROTEUS_TRACE_OUTPUT=1 PROTEUS_OPT_PIPELINE='default<Oz>' ./kernel_pass_pipeline.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECKz
-// RUN: rm -rf .proteus
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_CODEGEN=serial PROTEUS_TRACE_OUTPUT=1 %build/kernel_pass_pipeline.%ext | %FILECHECK %s --check-prefixes=CHECK
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 PROTEUS_CODEGEN=serial PROTEUS_TRACE_OUTPUT=1 PROTEUS_OPT_PIPELINE='default<O3>' %build/kernel_pass_pipeline.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK3
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 PROTEUS_CODEGEN=serial PROTEUS_TRACE_OUTPUT=1 PROTEUS_OPT_PIPELINE='default<O2>' %build/kernel_pass_pipeline.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK2
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 PROTEUS_CODEGEN=serial PROTEUS_TRACE_OUTPUT=1 PROTEUS_OPT_PIPELINE='default<O1>' %build/kernel_pass_pipeline.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK1
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 PROTEUS_CODEGEN=serial PROTEUS_TRACE_OUTPUT=1 PROTEUS_OPT_PIPELINE='default<Os>' %build/kernel_pass_pipeline.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECKs
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 PROTEUS_CODEGEN=serial PROTEUS_TRACE_OUTPUT=1 PROTEUS_OPT_PIPELINE='default<Oz>' %build/kernel_pass_pipeline.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECKz
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 #include <climits>
 #include <cstdio>

--- a/tests/gpu/kernel_preset_bounds.cpp
+++ b/tests/gpu/kernel_preset_bounds.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_TRACE_OUTPUT=1 ./kernel_preset_bounds.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/kernel_preset_bounds.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./kernel_preset_bounds.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/kernel_preset_bounds.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 #include <climits>
 #include <cstdio>

--- a/tests/gpu/kernel_repeat.cpp
+++ b/tests/gpu/kernel_repeat.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_TRACE_OUTPUT=1 ./kernel_repeat.%ext |  %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/kernel_repeat.%ext |  %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./kernel_repeat.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/kernel_repeat.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 #include <climits>
 #include <cstdio>

--- a/tests/gpu/kernel_repeat_api.cpp
+++ b/tests/gpu/kernel_repeat_api.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_TRACE_OUTPUT=1 ./kernel_repeat_api.%ext |  %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/kernel_repeat_api.%ext |  %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./kernel_repeat_api.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/kernel_repeat_api.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 #include <climits>
 #include <cstdio>

--- a/tests/gpu/kernel_unused_gvar.cpp
+++ b/tests/gpu/kernel_unused_gvar.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: ./kernel_unused_gvar.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/kernel_unused_gvar.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./kernel_unused_gvar.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/kernel_unused_gvar.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 #include <climits>
 #include <cstdio>

--- a/tests/gpu/kernels_gvar.cpp
+++ b/tests/gpu/kernels_gvar.cpp
@@ -1,8 +1,11 @@
-// RUN: rm -rf .proteus
-// RUN: ./kernels_gvar.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// clang-format off
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/kernels_gvar.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./kernels_gvar.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/kernels_gvar.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
+// clang-format on
+
 #include <climits>
 #include <cstdio>
 

--- a/tests/gpu/lambda_def.cpp
+++ b/tests/gpu/lambda_def.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_TRACE_OUTPUT=1 ./lambda_def.%ext |  %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/lambda_def.%ext |  %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./lambda_def.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/lambda_def.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <cstdio>
@@ -26,9 +26,10 @@ int main() {
   proteus::init();
 
   int A = 42;
-  auto Lambda =
-      [=, A = proteus::jit_variable(A)] __device__()
-          __attribute__((annotate("jit"))) { printf("Lambda A %d\n", A); };
+  auto Lambda = [ =, A = proteus::jit_variable(A) ] __device__()
+      __attribute__((annotate("jit"))) {
+    printf("Lambda A %d\n", A);
+  };
   run(Lambda);
   run(Lambda);
   run(Lambda);

--- a/tests/gpu/lambda_host_device.cpp
+++ b/tests/gpu/lambda_host_device.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_TRACE_OUTPUT=1 ./lambda_host_device.%ext |  %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/lambda_host_device.%ext |  %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./lambda_host_device.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/lambda_host_device.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <iostream>
@@ -26,7 +26,7 @@ template <typename T> void launcher(T &&LB) {
 int main() {
   proteus::init();
   int A = 42;
-  launcher([=, A = proteus::jit_variable(A)] __host__ __device__()
+  launcher([ =, A = proteus::jit_variable(A) ] __host__ __device__()
                __attribute__((annotate("jit"))) { printf("Lambda %d\n", A); });
   proteus::finalize();
 }

--- a/tests/gpu/lambda_multiple.cpp
+++ b/tests/gpu/lambda_multiple.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_TRACE_OUTPUT=1 ./lambda_multiple.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/lambda_multiple.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./lambda_multiple.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/lambda_multiple.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <iostream>

--- a/tests/gpu/mix_attr_api.cpp
+++ b/tests/gpu/mix_attr_api.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_TRACE_OUTPUT=1 ./mix_attr_api.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/mix_attr_api.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./mix_attr_api.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/mix_attr_api.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 #include <climits>
 #include <cstdio>

--- a/tests/gpu/scale100-gvar/main.cpp
+++ b/tests/gpu/scale100-gvar/main.cpp
@@ -1,8 +1,10 @@
-// RUN: rm -rf .proteus
-// RUN: ./scale100-gvar.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// clang-format off
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/scale100-gvar/scale100-gvar.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./scale100-gvar.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/scale100-gvar/scale100-gvar.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
+// clang-format on
 
 #include "../gpu_common.h"
 #include <cstdio>

--- a/tests/gpu/scale100/main.cpp
+++ b/tests/gpu/scale100/main.cpp
@@ -1,8 +1,10 @@
-// RUN: rm -rf .proteus
-// RUN: ./scale100.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// clang-format off
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/scale100/scale100.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./scale100.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/scale100/scale100.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
+// clang-format on
 
 #include "../gpu_common.h"
 #include <cstdio>

--- a/tests/gpu/shared_array.cpp
+++ b/tests/gpu/shared_array.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_TRACE_OUTPUT=1 ./shared_array.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/shared_array.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./shared_array.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/shared_array.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 #include <climits>
 #include <cstdio>

--- a/tests/gpu/types.cpp
+++ b/tests/gpu/types.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_TRACE_OUTPUT=1 ./types.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/types.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./types.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/types.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <cstdio>

--- a/tests/gpu/types_api.cpp
+++ b/tests/gpu/types_api.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_TRACE_OUTPUT=1 ./types_api.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/types_api.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./types_api.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/types_api.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <cstdio>

--- a/tests/gpu/types_jit_array.cpp
+++ b/tests/gpu/types_jit_array.cpp
@@ -1,9 +1,9 @@
 // clang-format off
-// RUN: rm -rf .proteus
-// RUN: PROTEUS_TRACE_OUTPUT=1 ./types_jit_array.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" PROTEUS_TRACE_OUTPUT=1 %build/types_jit_array.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
 // Second run uses the object cache.
-// RUN: ./types_jit_array.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// RUN: rm -rf .proteus
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/types_jit_array.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
 // clang-format on
 
 #include <climits>

--- a/tests/integration/hip/cmake-shared_lib_and_exe-static_proteus/main.cpp
+++ b/tests/integration/hip/cmake-shared_lib_and_exe-static_proteus/main.cpp
@@ -1,8 +1,3 @@
-// rm -rf .proteus
-// RUN: ./daxpy.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
-// Second run uses the object cache.
-// RUN: ./daxpy.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
-// rm -rf .proteus
 #include <cstddef>
 #include <cstdlib>
 #include <iostream>
@@ -35,11 +30,3 @@ int main(int argc, char **argv) {
   gpuErrCheck(gpuFree(X));
   gpuErrCheck(gpuFree(Y));
 }
-
-// CHECK: 0
-// CHECK: 19944.1
-// CHECK: 39888.2
-// CHECK: JitCache hits 1 total 2
-// CHECK: HashValue {{[0-9]+}} NumExecs 2 NumHits 1
-// CHECK-FIRST: JitStorageCache hits 0 total 1
-// CHECK-SECOND: JitStorageCache hits 1 total 1


### PR DESCRIPTION
- Add PROTEUS_CACHE_DIR env var to isolate cache directories
- Update lit configurations
    - Create tmp dir for exec_root of the lit tests to avoid races on lit_test_time.txt
    - Add %build lit variable that points to the build directory and update runlines to call the executing program relative to that
    - Add atexit handler to delete tmp dirs
- Update and clean up tests
- Update test yaml and scripts