### PR TITLE
PJ-DSL: Turn fp-contract on

### DIFF
--- a/src/lib/Frontend/Func.cpp
+++ b/src/lib/Frontend/Func.cpp
@@ -7,6 +7,16 @@ FuncBase::FuncBase(JitModule &J, FunctionCallee FC)
   Function *F = cast<Function>(FC.getCallee());
   BasicBlock::Create(F->getContext(), "entry", F);
   Name = F->getName();
+
+  // Clang enables the 'contract' rewrite rule by default to enable FMA
+  // instructions.
+  // (Controllable via the '-ffp-contract' flag.)
+  // Without this, PJ-DSL performance does not match JIT frontends
+  // that use FMA instructions.
+  // TODO: Make such things configurable.
+  FastMathFlags FMF;
+  FMF.setAllowContract(true);
+  IRB.setFastMathFlags(FMF);
 }
 
 IRBuilderBase &FuncBase::getIRBuilder() {

--- a/tests/frontend/cpu/add_vectors.cpp
+++ b/tests/frontend/cpu/add_vectors.cpp
@@ -75,6 +75,7 @@ int main() {
 }
 
 // clang-format off
+// CHECK: fadd contract
 // CHECK: Verification successful!
 // CHECK-FIRST: JitStorageCache hits 0 total 1
 // CHECK-SECOND: JitStorageCache hits 1 total 1

--- a/tests/frontend/gpu/adam.cpp
+++ b/tests/frontend/gpu/adam.cpp
@@ -250,7 +250,7 @@ int main(int argc, char *argv[]) {
 // CHECK-NEXT: p[2] = -0.592634
 // CHECK-NEXT: p[3] = -0.588154
 // CHECK-NEXT: p[4] = -0.593454
-// CHECK-NEXT: p[5] = -0.59199
+// CHECK-NEXT: p[5] = -0.591989
 // CHECK-NEXT: p[6] = -0.573486
 // CHECK-NEXT: p[7] = -0.599872
 // CHECK-NEXT: p[8] = -0.58157

--- a/tests/frontend/gpu/adam_runconst.cpp
+++ b/tests/frontend/gpu/adam_runconst.cpp
@@ -254,7 +254,7 @@ int main(int argc, char *argv[]) {
 // CHECK-NEXT: p[2] = -0.592634
 // CHECK-NEXT: p[3] = -0.588154
 // CHECK-NEXT: p[4] = -0.593454
-// CHECK-NEXT: p[5] = -0.59199
+// CHECK-NEXT: p[5] = -0.591989
 // CHECK-NEXT: p[6] = -0.573486
 // CHECK-NEXT: p[7] = -0.599872
 // CHECK-NEXT: p[8] = -0.58157

--- a/tests/frontend/gpu/add_vectors.cpp
+++ b/tests/frontend/gpu/add_vectors.cpp
@@ -107,6 +107,7 @@ int main() {
 }
 
 // clang-format off
+// CHECK: fadd contract
 // CHECK: Verification successful!
 // CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
 // CHECK-FIRST: JitStorageCache hits 0 total 1


### PR DESCRIPTION
Since v14, clang sets the flag [`-ffp-contract=on`](https://releases.llvm.org/14.0.0/tools/clang/docs/ReleaseNotes.html#floating-point-support-in-clang) by default, enabling IR instruction rewrites into FMA.
By setting this flag in PJ-DSL's IRBuilder, we match Clang's default behavior, which the CPP and annotation JIT frontends both use.

This improves PJ-DSL performance, eliminating most of its slowdown relative to the other frontends (remaining slowdown is attributed to no launch bound specialization).

GEMM (HIP, Tuolumne) without fp-contract:
```
Average over 25 trials: 89.928 ms
```

GEMM (HIP, Tuolumne) with fp-contract:
```
Average over 25 trials: 83.211 ms
```

One value in the `adam` tests changes as a result. FMA is generally considered more accurate than the unfused multiply + add because it rounds once, not twice.

This PR directly fixes an acute performance regression. Longer term, we should allow the user to choose fast math flags, with default values matching Clang.