### PR TITLE
PJ-DSL: Call Functions with Args

### DIFF
--- a/include/proteus/Frontend/Func.hpp
+++ b/include/proteus/Frontend/Func.hpp
@@ -30,11 +30,12 @@ template <typename RetT_, typename... ArgT> struct FnSig<RetT_(ArgT...)> {
   using RetT = RetT_;
 };
 
-  template <typename RetT, typename... ArgT>
-  static FunctionCallee getFunctionCallee(Module &M, LLVMContext &Ctx, StringRef Name, ArgTypeList<ArgT...>) {
-    return M.getOrInsertFunction(Name, TypeMap<RetT>::get(Ctx),
-                                  TypeMap<ArgT>::get(Ctx)...);
-  }
+template <typename RetT, typename... ArgT>
+static FunctionCallee getFunctionCallee(Module &M, LLVMContext &Ctx,
+                                        StringRef Name, ArgTypeList<ArgT...>) {
+  return M.getOrInsertFunction(Name, TypeMap<RetT>::get(Ctx),
+                               TypeMap<ArgT>::get(Ctx)...);
+}
 
 using namespace llvm;
 

--- a/include/proteus/Frontend/Func.hpp
+++ b/include/proteus/Frontend/Func.hpp
@@ -188,12 +188,12 @@ public:
   template <typename RetT, typename... ArgT>
   std::enable_if_t<std::is_void_v<RetT>, void> call(StringRef Name);
 
-  template <typename RetT, typename... ArgVarTs>
+  template <typename RetT, typename... ArgT>
   std::enable_if_t<!std::is_void_v<RetT>, Var &> call(StringRef Name,
-                                                      ArgVarTs &...Args);
-  template <typename RetT, typename... ArgVarTs>
+                                                      std::initializer_list<std::reference_wrapper<Var>> Args);
+  template <typename RetT, typename... ArgT>
   std::enable_if_t<std::is_void_v<RetT>, void> call(StringRef Name,
-                                                    ArgVarTs &...Args);
+                                                    std::initializer_list<std::reference_wrapper<Var>> Args);
 
   template <typename BuiltinFuncT>
   decltype(auto) callBuiltin(BuiltinFuncT &&BuiltinFunc) {

--- a/include/proteus/Frontend/Func.hpp
+++ b/include/proteus/Frontend/Func.hpp
@@ -188,6 +188,13 @@ public:
   template <typename RetT, typename... ArgT>
   std::enable_if_t<std::is_void_v<RetT>, void> call(StringRef Name);
 
+  template <typename RetT, typename... ArgVarTs>
+  std::enable_if_t<!std::is_void_v<RetT>, Var &>
+  call(StringRef Name, ArgVarTs &...Args);
+  template <typename RetT, typename... ArgVarTs>
+  std::enable_if_t<std::is_void_v<RetT>, void>
+  call(StringRef Name, ArgVarTs &...Args);
+
   template <typename BuiltinFuncT>
   decltype(auto) callBuiltin(BuiltinFuncT &&BuiltinFunc) {
     using RetT = std::invoke_result_t<BuiltinFuncT &, FuncBase &>;

--- a/include/proteus/Frontend/Func.hpp
+++ b/include/proteus/Frontend/Func.hpp
@@ -189,11 +189,11 @@ public:
   std::enable_if_t<std::is_void_v<RetT>, void> call(StringRef Name);
 
   template <typename RetT, typename... ArgT, typename... ArgVars>
-  std::enable_if_t<!std::is_void_v<RetT>, Var &>
-  call(StringRef Name, ArgVars &&...ArgsVars);
+  std::enable_if_t<!std::is_void_v<RetT>, Var &> call(StringRef Name,
+                                                      ArgVars &&...ArgsVars);
   template <typename RetT, typename... ArgT, typename... ArgVars>
-  std::enable_if_t<std::is_void_v<RetT>, void>
-  call(StringRef Name, ArgVars &&...ArgsVars);
+  std::enable_if_t<std::is_void_v<RetT>, void> call(StringRef Name,
+                                                    ArgVars &&...ArgsVars);
 
   template <typename BuiltinFuncT>
   decltype(auto) callBuiltin(BuiltinFuncT &&BuiltinFunc) {

--- a/include/proteus/Frontend/Func.hpp
+++ b/include/proteus/Frontend/Func.hpp
@@ -188,12 +188,12 @@ public:
   template <typename RetT, typename... ArgT>
   std::enable_if_t<std::is_void_v<RetT>, void> call(StringRef Name);
 
-  template <typename RetT, typename... ArgT>
+  template <typename RetT, typename... ArgT, typename... ArgVars>
   std::enable_if_t<!std::is_void_v<RetT>, Var &>
-  call(StringRef Name, std::initializer_list<std::reference_wrapper<Var>> Args);
-  template <typename RetT, typename... ArgT>
+  call(StringRef Name, ArgVars &&...ArgsVars);
+  template <typename RetT, typename... ArgT, typename... ArgVars>
   std::enable_if_t<std::is_void_v<RetT>, void>
-  call(StringRef Name, std::initializer_list<std::reference_wrapper<Var>> Args);
+  call(StringRef Name, ArgVars &&...ArgsVars);
 
   template <typename BuiltinFuncT>
   decltype(auto) callBuiltin(BuiltinFuncT &&BuiltinFunc) {

--- a/include/proteus/Frontend/Func.hpp
+++ b/include/proteus/Frontend/Func.hpp
@@ -30,13 +30,6 @@ template <typename RetT_, typename... ArgT> struct FnSig<RetT_(ArgT...)> {
   using RetT = RetT_;
 };
 
-template <typename RetT, typename... ArgT>
-static FunctionCallee getFunctionCallee(Module &M, LLVMContext &Ctx,
-                                        StringRef Name, ArgTypeList<ArgT...>) {
-  return M.getOrInsertFunction(Name, TypeMap<RetT>::get(Ctx),
-                               TypeMap<ArgT>::get(Ctx)...);
-}
-
 using namespace llvm;
 
 struct EmptyLambda {

--- a/include/proteus/Frontend/Func.hpp
+++ b/include/proteus/Frontend/Func.hpp
@@ -189,11 +189,11 @@ public:
   std::enable_if_t<std::is_void_v<RetT>, void> call(StringRef Name);
 
   template <typename RetT, typename... ArgVarTs>
-  std::enable_if_t<!std::is_void_v<RetT>, Var &>
-  call(StringRef Name, ArgVarTs &...Args);
+  std::enable_if_t<!std::is_void_v<RetT>, Var &> call(StringRef Name,
+                                                      ArgVarTs &...Args);
   template <typename RetT, typename... ArgVarTs>
-  std::enable_if_t<std::is_void_v<RetT>, void>
-  call(StringRef Name, ArgVarTs &...Args);
+  std::enable_if_t<std::is_void_v<RetT>, void> call(StringRef Name,
+                                                    ArgVarTs &...Args);
 
   template <typename BuiltinFuncT>
   decltype(auto) callBuiltin(BuiltinFuncT &&BuiltinFunc) {

--- a/include/proteus/Frontend/Func.hpp
+++ b/include/proteus/Frontend/Func.hpp
@@ -189,11 +189,11 @@ public:
   std::enable_if_t<std::is_void_v<RetT>, void> call(StringRef Name);
 
   template <typename RetT, typename... ArgT>
-  std::enable_if_t<!std::is_void_v<RetT>, Var &> call(StringRef Name,
-                                                      std::initializer_list<std::reference_wrapper<Var>> Args);
+  std::enable_if_t<!std::is_void_v<RetT>, Var &>
+  call(StringRef Name, std::initializer_list<std::reference_wrapper<Var>> Args);
   template <typename RetT, typename... ArgT>
-  std::enable_if_t<std::is_void_v<RetT>, void> call(StringRef Name,
-                                                    std::initializer_list<std::reference_wrapper<Var>> Args);
+  std::enable_if_t<std::is_void_v<RetT>, void>
+  call(StringRef Name, std::initializer_list<std::reference_wrapper<Var>> Args);
 
   template <typename BuiltinFuncT>
   decltype(auto) callBuiltin(BuiltinFuncT &&BuiltinFunc) {

--- a/include/proteus/JitFrontend.hpp
+++ b/include/proteus/JitFrontend.hpp
@@ -147,8 +147,7 @@ public:
   JitModule(JitModule &&) = delete;
   JitModule &operator=(JitModule &&) = delete;
 
-  template <typename Sig>
-  auto &addFunction(StringRef Name) {
+  template <typename Sig> auto &addFunction(StringRef Name) {
     using RetT = typename FnSig<Sig>::RetT;
     using ArgT = typename FnSig<Sig>::ArgsTList;
 
@@ -242,14 +241,13 @@ public:
 };
 
 template <typename Sig>
-std::enable_if_t<
-    !std::is_void_v<typename FnSig<Sig>::RetT>, Var &>
+std::enable_if_t<!std::is_void_v<typename FnSig<Sig>::RetT>, Var &>
 FuncBase::call(StringRef Name) {
   using RetT = typename FnSig<Sig>::RetT;
   auto *F = getFunction();
   Module &M = *F->getParent();
   LLVMContext &Ctx = F->getContext();
-  
+
   using RetT = typename FnSig<Sig>::RetT;
   using ArgT = typename FnSig<Sig>::ArgsTList;
   FunctionCallee Callee = getFunctionCallee<RetT>(M, Ctx, Name, ArgT{});
@@ -260,8 +258,7 @@ FuncBase::call(StringRef Name) {
 }
 
 template <typename Sig>
-std::enable_if_t<
-    std::is_void_v<typename FnSig<Sig>::RetT>, void>
+std::enable_if_t<std::is_void_v<typename FnSig<Sig>::RetT>, void>
 FuncBase::call(StringRef Name) {
   using RetT = typename FnSig<Sig>::RetT;
   auto *F = getFunction();
@@ -275,8 +272,7 @@ FuncBase::call(StringRef Name) {
 }
 
 template <typename Sig, typename... ArgVars>
-std::enable_if_t<
-    !std::is_void_v<typename FnSig<Sig>::RetT>, Var &>
+std::enable_if_t<!std::is_void_v<typename FnSig<Sig>::RetT>, Var &>
 FuncBase::call(StringRef Name, ArgVars &&...ArgsVars) {
   auto *F = getFunction();
   Module &M = *F->getParent();
@@ -293,8 +289,7 @@ FuncBase::call(StringRef Name, ArgVars &&...ArgsVars) {
 }
 
 template <typename Sig, typename... ArgVars>
-std::enable_if_t<
-    std::is_void_v<typename FnSig<Sig>::RetT>, void>
+std::enable_if_t<std::is_void_v<typename FnSig<Sig>::RetT>, void>
 FuncBase::call(StringRef Name, ArgVars &&...ArgsVars) {
   auto *F = getFunction();
   Module &M = *F->getParent();

--- a/include/proteus/JitFrontend.hpp
+++ b/include/proteus/JitFrontend.hpp
@@ -248,7 +248,8 @@ std::enable_if_t<std::is_void_v<RetT>, void> FuncBase::call(StringRef Name) {
 
 template <typename RetT, typename... ArgT>
 std::enable_if_t<!std::is_void_v<RetT>, Var &>
-FuncBase::call(StringRef Name, std::initializer_list<std::reference_wrapper<Var>> Args) {
+FuncBase::call(StringRef Name,
+               std::initializer_list<std::reference_wrapper<Var>> Args) {
   auto *F = getFunction();
   Module &M = *F->getParent();
   LLVMContext &Ctx = F->getContext();
@@ -268,8 +269,9 @@ FuncBase::call(StringRef Name, std::initializer_list<std::reference_wrapper<Var>
 }
 
 template <typename RetT, typename... ArgT>
-std::enable_if_t<std::is_void_v<RetT>, void> FuncBase::call(StringRef Name,
-                                                            std::initializer_list<std::reference_wrapper<Var>> Args) {
+std::enable_if_t<std::is_void_v<RetT>, void>
+FuncBase::call(StringRef Name,
+               std::initializer_list<std::reference_wrapper<Var>> Args) {
   auto *F = getFunction();
   Module &M = *F->getParent();
   LLVMContext &Ctx = F->getContext();

--- a/include/proteus/JitFrontend.hpp
+++ b/include/proteus/JitFrontend.hpp
@@ -263,8 +263,8 @@ FuncBase::call(StringRef Name, ArgVarTs &...Args) {
 }
 
 template <typename RetT, typename... ArgVarTs>
-std::enable_if_t<std::is_void_v<RetT>, void>
-FuncBase::call(StringRef Name, ArgVarTs &...Args) {
+std::enable_if_t<std::is_void_v<RetT>, void> FuncBase::call(StringRef Name,
+                                                            ArgVarTs &...Args) {
   auto *F = getFunction();
   Module &M = *F->getParent();
   LLVMContext &Ctx = F->getContext();

--- a/include/proteus/JitFrontend.hpp
+++ b/include/proteus/JitFrontend.hpp
@@ -248,8 +248,7 @@ std::enable_if_t<std::is_void_v<RetT>, void> FuncBase::call(StringRef Name) {
 
 template <typename RetT, typename... ArgT, typename... ArgVars>
 std::enable_if_t<!std::is_void_v<RetT>, Var &>
-FuncBase::call(StringRef Name,
-               ArgVars &&...ArgsVars) {
+FuncBase::call(StringRef Name, ArgVars &&...ArgsVars) {
   auto *F = getFunction();
   Module &M = *F->getParent();
   LLVMContext &Ctx = F->getContext();
@@ -265,8 +264,7 @@ FuncBase::call(StringRef Name,
 
 template <typename RetT, typename... ArgT, typename... ArgVars>
 std::enable_if_t<std::is_void_v<RetT>, void>
-FuncBase::call(StringRef Name,
-               ArgVars &&...ArgsVars) {
+FuncBase::call(StringRef Name, ArgVars &&...ArgsVars) {
   auto *F = getFunction();
   Module &M = *F->getParent();
   LLVMContext &Ctx = F->getContext();

--- a/include/proteus/JitFrontend.hpp
+++ b/include/proteus/JitFrontend.hpp
@@ -38,6 +38,31 @@ private:
   HashT ModuleHash = 0;
   bool IsCompiled = false;
 
+  template <typename... ArgT> struct KernelHandle;
+
+  template <typename RetT, typename... ArgT>
+  Func<RetT, ArgT...> &buildFuncFromArgsList(FunctionCallee FC,
+                                             ArgTypeList<ArgT...>) {
+    auto TypedFn = std::make_unique<Func<RetT, ArgT...>>(*this, FC, Dispatch);
+    Func<RetT, ArgT...> &TypedFnRef = *TypedFn;
+    std::unique_ptr<FuncBase> &Fn = Functions.emplace_back(std::move(TypedFn));
+    Fn->declArgs<ArgT...>();
+    return TypedFnRef;
+  }
+
+  template <typename... ArgT>
+  KernelHandle<ArgT...> buildKernelFromArgsList(FunctionCallee FC,
+                                                ArgTypeList<ArgT...>) {
+    auto TypedFn = std::make_unique<Func<void, ArgT...>>(*this, FC, Dispatch);
+    Func<void, ArgT...> &TypedFnRef = *TypedFn;
+    std::unique_ptr<FuncBase> &Fn = Functions.emplace_back(std::move(TypedFn));
+
+    Fn->declArgs<ArgT...>();
+
+    setKernel(*Fn);
+    return KernelHandle<ArgT...>{TypedFnRef, *this};
+  }
+
   template <typename... ArgT> struct KernelHandle {
     Func<void, ArgT...> &F;
     JitModule &M;
@@ -122,32 +147,34 @@ public:
   JitModule(JitModule &&) = delete;
   JitModule &operator=(JitModule &&) = delete;
 
-  template <typename RetT, typename... ArgT>
-  Func<RetT, ArgT...> &addFunction(StringRef Name) {
+  template <typename Sig>
+  auto &addFunction(StringRef Name) {
+    using RetT = typename FnSig<Sig>::RetT;
+    using ArgT = typename FnSig<Sig>::ArgsTList;
+
     if (IsCompiled)
       PROTEUS_FATAL_ERROR(
           "The module is compiled, no further code can be added");
 
     Mod->setTargetTriple(TargetTriple);
-    FunctionCallee FC;
-    FC = Mod->getOrInsertFunction(Name, TypeMap<RetT>::get(*Ctx),
-                                  TypeMap<ArgT>::get(*Ctx)...);
+    FunctionCallee FC = getFunctionCallee<RetT>(*Mod, *Ctx, Name, ArgT{});
+
     Function *F = dyn_cast<Function>(FC.getCallee());
     if (!F)
       PROTEUS_FATAL_ERROR("Unexpected");
-    auto TypedFn = std::make_unique<Func<RetT, ArgT...>>(*this, FC, Dispatch);
-    Func<RetT, ArgT...> &TypedFnRef = *TypedFn;
-    std::unique_ptr<FuncBase> &Fn = Functions.emplace_back(std::move(TypedFn));
 
-    Fn->declArgs<ArgT...>();
-    return TypedFnRef;
+    return buildFuncFromArgsList<RetT>(FC, ArgT{});
   }
 
   bool isCompiled() const { return IsCompiled; }
 
   const Module &getModule() const { return *Mod; }
 
-  template <typename... ArgT> KernelHandle<ArgT...> addKernel(StringRef Name) {
+  template <typename Sig> auto addKernel(StringRef Name) {
+    using RetT = typename FnSig<Sig>::RetT;
+    static_assert(std::is_void_v<RetT>, "Kernels must have void return type");
+    using ArgT = typename FnSig<Sig>::ArgsTList;
+
     if (IsCompiled)
       PROTEUS_FATAL_ERROR(
           "The module is compiled, no further code can be added");
@@ -156,20 +183,12 @@ public:
       PROTEUS_FATAL_ERROR("Expected a device module for addKernel");
 
     Mod->setTargetTriple(TargetTriple);
-    FunctionCallee FC;
-    FC = Mod->getOrInsertFunction(Name, TypeMap<void>::get(*Ctx),
-                                  TypeMap<ArgT>::get(*Ctx)...);
+    FunctionCallee FC = getFunctionCallee<void>(*Mod, *Ctx, Name, ArgT{});
     Function *F = dyn_cast<Function>(FC.getCallee());
     if (!F)
       PROTEUS_FATAL_ERROR("Unexpected");
-    auto TypedFn = std::make_unique<Func<void, ArgT...>>(*this, FC, Dispatch);
-    Func<void, ArgT...> &TypedFnRef = *TypedFn;
-    std::unique_ptr<FuncBase> &Fn = Functions.emplace_back(std::move(TypedFn));
 
-    Fn->declArgs<ArgT...>();
-
-    setKernel(*Fn);
-    return KernelHandle<ArgT...>{TypedFnRef, *this};
+    return buildKernelFromArgsList(FC, ArgT{});
   }
 
   void compile(bool Verify = false) {
@@ -222,46 +241,50 @@ public:
   void print() { Mod->print(outs(), nullptr); }
 };
 
-template <typename Sig, typename... ArgT>
+template <typename Sig>
 std::enable_if_t<
-    !std::is_void_v<typename FuncBase::template FnSig<Sig>::return_t>, Var &>
+    !std::is_void_v<typename FnSig<Sig>::RetT>, Var &>
 FuncBase::call(StringRef Name) {
-  using RetT = typename FuncBase::template FnSig<Sig>::return_t;
+  using RetT = typename FnSig<Sig>::RetT;
   auto *F = getFunction();
   Module &M = *F->getParent();
   LLVMContext &Ctx = F->getContext();
-  FunctionCallee Callee = M.getOrInsertFunction(Name, TypeMap<RetT>::get(Ctx),
-                                                TypeMap<ArgT>::get(Ctx)...);
+  
+  using RetT = typename FnSig<Sig>::RetT;
+  using ArgT = typename FnSig<Sig>::ArgsTList;
+  FunctionCallee Callee = getFunctionCallee<RetT>(M, Ctx, Name, ArgT{});
   auto *Call = IRB.CreateCall(Callee);
   Var &Ret = declVarInternal("ret", TypeMap<RetT>::get(Ctx));
   Ret.storeValue(Call);
   return Ret;
 }
 
-template <typename Sig, typename... ArgT>
+template <typename Sig>
 std::enable_if_t<
-    std::is_void_v<typename FuncBase::template FnSig<Sig>::return_t>, void>
+    std::is_void_v<typename FnSig<Sig>::RetT>, void>
 FuncBase::call(StringRef Name) {
-  using RetT = typename FuncBase::template FnSig<Sig>::return_t;
+  using RetT = typename FnSig<Sig>::RetT;
   auto *F = getFunction();
   Module &M = *F->getParent();
   LLVMContext &Ctx = F->getContext();
-  FunctionCallee Callee = M.getOrInsertFunction(Name, TypeMap<RetT>::get(Ctx),
-                                                TypeMap<ArgT>::get(Ctx)...);
+
+  using RetT = typename FnSig<Sig>::RetT;
+  using ArgT = typename FnSig<Sig>::ArgsTList;
+  FunctionCallee Callee = getFunctionCallee<RetT>(M, Ctx, Name, ArgT{});
   IRB.CreateCall(Callee);
 }
 
-template <typename Sig, typename... ArgT, typename... ArgVars>
+template <typename Sig, typename... ArgVars>
 std::enable_if_t<
-    !std::is_void_v<typename FuncBase::template FnSig<Sig>::return_t>, Var &>
+    !std::is_void_v<typename FnSig<Sig>::RetT>, Var &>
 FuncBase::call(StringRef Name, ArgVars &&...ArgsVars) {
   auto *F = getFunction();
   Module &M = *F->getParent();
   LLVMContext &Ctx = F->getContext();
 
-  using RetT = typename FuncBase::template FnSig<Sig>::return_t;
-  FunctionCallee Callee = M.getOrInsertFunction(Name, TypeMap<RetT>::get(Ctx),
-                                                TypeMap<ArgT>::get(Ctx)...);
+  using RetT = typename FnSig<Sig>::RetT;
+  using ArgT = typename FnSig<Sig>::ArgsTList;
+  FunctionCallee Callee = getFunctionCallee<RetT>(M, Ctx, Name, ArgT{});
   auto *Call = IRB.CreateCall(Callee, {ArgsVars.getValue()...});
 
   Var &Ret = declVarInternal("ret", TypeMap<RetT>::get(Ctx));
@@ -269,17 +292,17 @@ FuncBase::call(StringRef Name, ArgVars &&...ArgsVars) {
   return Ret;
 }
 
-template <typename Sig, typename... ArgT, typename... ArgVars>
+template <typename Sig, typename... ArgVars>
 std::enable_if_t<
-    std::is_void_v<typename FuncBase::template FnSig<Sig>::return_t>, void>
+    std::is_void_v<typename FnSig<Sig>::RetT>, void>
 FuncBase::call(StringRef Name, ArgVars &&...ArgsVars) {
   auto *F = getFunction();
   Module &M = *F->getParent();
   LLVMContext &Ctx = F->getContext();
 
-  using RetT = typename FuncBase::template FnSig<Sig>::return_t;
-  FunctionCallee Callee = M.getOrInsertFunction(Name, TypeMap<RetT>::get(Ctx),
-                                                TypeMap<ArgT>::get(Ctx)...);
+  using RetT = typename FnSig<Sig>::RetT;
+  using ArgT = typename FnSig<Sig>::ArgsTList;
+  FunctionCallee Callee = getFunctionCallee<RetT>(M, Ctx, Name, ArgT{});
   IRB.CreateCall(Callee, {ArgsVars.getValue()...});
 }
 

--- a/tests/frontend/cpu/add_vectors.cpp
+++ b/tests/frontend/cpu/add_vectors.cpp
@@ -16,7 +16,7 @@ int main() {
 
   // Add a function with the signature:
   //  void add_vectors(double *A, double *B, size_t N)
-  auto &F = J.addFunction<void, double *, double *, size_t>("add_vectors");
+  auto &F = J.addFunction<void(double *, double *, size_t)>("add_vectors");
 
   // Begin the function body.
   F.beginFunction();

--- a/tests/frontend/cpu/add_vectors_runconst.cpp
+++ b/tests/frontend/cpu/add_vectors_runconst.cpp
@@ -16,7 +16,7 @@ auto createJitFunction(size_t N) {
 
   // Add a function with the signature: void add_vectors(double *A, double *B)
   // using the vector size N as a runtime constant.
-  auto &F = J->addFunction<void, double *, double *>("add_vectors");
+  auto &F = J->addFunction<void(double *, double *)>("add_vectors");
 
   // Begin the function body.
   F.beginFunction();

--- a/tests/frontend/cpu/array.cpp
+++ b/tests/frontend/cpu/array.cpp
@@ -11,7 +11,7 @@ using namespace proteus;
 int main() {
   auto J = proteus::JitModule("host");
 
-  auto &F = J.addFunction<void, double *, double *>("arrays_test");
+  auto &F = J.addFunction<void(double *, double *)>("arrays_test");
 
   F.beginFunction();
   {

--- a/tests/frontend/cpu/external_call.cpp
+++ b/tests/frontend/cpu/external_call.cpp
@@ -22,7 +22,7 @@ int main() {
   auto J = proteus::JitModule();
   auto &F = J.addFunction<int>("ExternalCall");
   F.beginFunction();
-  { 
+  {
     F.call<void>("hello");
     auto &V1 = F.defVar<int>(22);
     auto &V2 = F.defVar<int>(20);

--- a/tests/frontend/cpu/external_call.cpp
+++ b/tests/frontend/cpu/external_call.cpp
@@ -20,7 +20,7 @@ int main() {
   proteus::init();
 
   auto J = proteus::JitModule();
-  auto &F = J.addFunction<int>("ExternalCall");
+  auto &F = J.addFunction<int(void)>("ExternalCall");
   F.beginFunction();
   {
     F.call<void(void)>("hello");
@@ -34,7 +34,7 @@ int main() {
   J.print();
   J.compile();
 
-  auto V = F();
+  int V = F();
   std::cout << "V " << V << "\n";
 
   proteus::finalize();

--- a/tests/frontend/cpu/external_call.cpp
+++ b/tests/frontend/cpu/external_call.cpp
@@ -13,28 +13,36 @@
 
 extern "C" {
 void hello() { std::cout << "Hello!\n"; }
+int add(int a, int b) { return a + b; }
 }
 
 int main() {
   proteus::init();
 
   auto J = proteus::JitModule();
-  auto &F = J.addFunction<void>("ExternalCall");
+  auto &F = J.addFunction<int>("ExternalCall");
   F.beginFunction();
-  { F.call<void>("hello"); }
-  F.ret();
+  { 
+    F.call<void>("hello");
+    auto &V1 = F.defVar<int>(22);
+    auto &V2 = F.defVar<int>(20);
+    auto &V3 = F.call<int, int, int>("add", V1, V2);
+    F.ret(V3);
+  }
   F.endFunction();
 
   J.print();
   J.compile();
 
-  F();
+  auto V = F();
+  std::cout << "V " << V << "\n";
 
   proteus::finalize();
   return 0;
 }
 
 // clang-format off
-//CHECK: Hello!
+// CHECK: Hello!
+// CHECK-NEXT: V 42
 // CHECK-FIRST: JitStorageCache hits 0 total 1
 // CHECK-SECOND: JitStorageCache hits 1 total 1

--- a/tests/frontend/cpu/external_call.cpp
+++ b/tests/frontend/cpu/external_call.cpp
@@ -23,10 +23,10 @@ int main() {
   auto &F = J.addFunction<int>("ExternalCall");
   F.beginFunction();
   {
-    F.call<void>("hello");
+    F.call<void(void)>("hello");
     auto &V1 = F.defVar<int>(22);
     auto &V2 = F.defVar<int>(20);
-    auto &V3 = F.call<int, int, int>("add", V1, V2);
+    auto &V3 = F.call<int(int, int)>("add", V1, V2);
     F.ret(V3);
   }
   F.endFunction();

--- a/tests/frontend/cpu/external_call.cpp
+++ b/tests/frontend/cpu/external_call.cpp
@@ -13,7 +13,7 @@
 
 extern "C" {
 void hello() { std::cout << "Hello!\n"; }
-int add(int a, int b) { return a + b; }
+int add(int A, int B) { return A + B; }
 }
 
 int main() {

--- a/tests/frontend/cpu/for.cpp
+++ b/tests/frontend/cpu/for.cpp
@@ -15,7 +15,7 @@ int main() {
   proteus::init();
 
   auto J = proteus::JitModule();
-  auto &F = J.addFunction<void, double *>("for");
+  auto &F = J.addFunction<void(double *)>("for");
 
   auto &I = F.declVar<int>("i");
   auto &Inc = F.declVar<int>("inc");

--- a/tests/frontend/cpu/if.cpp
+++ b/tests/frontend/cpu/if.cpp
@@ -15,7 +15,7 @@ int main() {
   proteus::init();
 
   auto J = proteus::JitModule();
-  auto &LT = J.addFunction<double, double, double>("if.lt");
+  auto &LT = J.addFunction<double(double, double)>("if.lt");
   {
     auto &Arg0 = LT.getArg(0);
     auto &Arg1 = LT.getArg(1);
@@ -32,7 +32,7 @@ int main() {
     LT.endFunction();
   }
 
-  auto &LE = J.addFunction<double, double, double>("if.le");
+  auto &LE = J.addFunction<double(double, double)>("if.le");
   {
     auto &Arg0 = LE.getArg(0);
     auto &Arg1 = LE.getArg(1);
@@ -49,7 +49,7 @@ int main() {
     LE.endFunction();
   }
 
-  auto &GT = J.addFunction<double, double, double>("if.gt");
+  auto &GT = J.addFunction<double(double, double)>("if.gt");
   {
     auto &Arg0 = GT.getArg(0);
     auto &Arg1 = GT.getArg(1);
@@ -66,7 +66,7 @@ int main() {
     GT.endFunction();
   }
 
-  auto &GE = J.addFunction<double, double, double>("if.ge");
+  auto &GE = J.addFunction<double(double, double)>("if.ge");
   {
     auto &Arg0 = GE.getArg(0);
     auto &Arg1 = GE.getArg(1);
@@ -83,7 +83,7 @@ int main() {
     GE.endFunction();
   }
 
-  auto &EQ = J.addFunction<double, double, double>("if.eq");
+  auto &EQ = J.addFunction<double(double, double)>("if.eq");
   {
     auto &Arg0 = EQ.getArg(0);
     auto &Arg1 = EQ.getArg(1);
@@ -100,7 +100,7 @@ int main() {
     EQ.endFunction();
   }
 
-  auto &NE = J.addFunction<double, double, double>("if.ne");
+  auto &NE = J.addFunction<double(double, double)>("if.ne");
   {
     auto &Arg0 = NE.getArg(0);
     auto &Arg1 = NE.getArg(1);

--- a/tests/frontend/cpu/internal_call.cpp
+++ b/tests/frontend/cpu/internal_call.cpp
@@ -22,7 +22,7 @@ auto createJitModule1() {
 
       Var &X = F1.defVar<double>(21);
       Var &C = F1.call<double>("f2");
-      Var &Res = F1.call<double, double, double>("f3", {X, C});
+      Var &Res = F1.call<double, double, double>("f3", X, C);
       V[0] = Res;
 
       F1.ret();

--- a/tests/frontend/cpu/internal_call.cpp
+++ b/tests/frontend/cpu/internal_call.cpp
@@ -20,8 +20,10 @@ auto createJitModule1() {
     {
       auto [V] = F1.getArgs();
 
-      Var &Ret = F1.call<double>("f2");
-      V[0] = Ret;
+      Var &X = F1.defVar<double>(21);
+      Var &C = F1.call<double>("f2");
+      Var &Res = F1.call<double>("f3", X, C);
+      V[0] = Res;
 
       F1.ret();
     }
@@ -32,12 +34,22 @@ auto createJitModule1() {
   {
     F2.beginFunction();
     {
-      Var &V = F2.declVar<double>();
-      V = 42;
-
-      F2.ret(V);
+      Var &C = F2.defVar<double>(2.0);
+      F2.ret(C);
     }
     F2.endFunction();
+  }
+
+  auto &F3 = J->addFunction<double, double, double>("f3");
+  {
+    F3.beginFunction();
+    {
+      auto [X, C] = F3.getArgs();
+      Var &P = F3.declVar<double>();
+      P = X * C;
+      F3.ret(P);
+    }
+    F3.endFunction();
   }
 
   return std::make_tuple(std::move(J), std::ref(F1), std::ref(F2));

--- a/tests/frontend/cpu/internal_call.cpp
+++ b/tests/frontend/cpu/internal_call.cpp
@@ -22,7 +22,7 @@ auto createJitModule1() {
 
       Var &X = F1.defVar<double>(21);
       Var &C = F1.call<double>("f2");
-      Var &Res = F1.call<double>("f3", X, C);
+      Var &Res = F1.call<double, double, double>("f3", {X, C});
       V[0] = Res;
 
       F1.ret();

--- a/tests/frontend/cpu/internal_call.cpp
+++ b/tests/frontend/cpu/internal_call.cpp
@@ -21,8 +21,8 @@ auto createJitModule1() {
       auto [V] = F1.getArgs();
 
       Var &X = F1.defVar<double>(21);
-      Var &C = F1.call<double>("f2");
-      Var &Res = F1.call<double, double, double>("f3", X, C);
+      Var &C = F1.call<double(void)>("f2");
+      Var &Res = F1.call<double(double, double)>("f3", X, C);
       V[0] = Res;
 
       F1.ret();

--- a/tests/frontend/cpu/internal_call.cpp
+++ b/tests/frontend/cpu/internal_call.cpp
@@ -14,7 +14,7 @@ using namespace proteus;
 auto createJitModule1() {
   auto J = std::make_unique<JitModule>("host");
 
-  auto &F1 = J->addFunction<void, double *>("f1");
+  auto &F1 = J->addFunction<void(double *)>("f1");
   {
     F1.beginFunction();
     {
@@ -30,7 +30,7 @@ auto createJitModule1() {
     F1.endFunction();
   }
 
-  auto &F2 = J->addFunction<double>("f2");
+  auto &F2 = J->addFunction<double(void)>("f2");
   {
     F2.beginFunction();
     {
@@ -40,7 +40,7 @@ auto createJitModule1() {
     F2.endFunction();
   }
 
-  auto &F3 = J->addFunction<double, double, double>("f3");
+  auto &F3 = J->addFunction<double(double, double)>("f3");
   {
     F3.beginFunction();
     {

--- a/tests/frontend/cpu/loopnest_1d.cpp
+++ b/tests/frontend/cpu/loopnest_1d.cpp
@@ -12,7 +12,7 @@
 
 static auto get1DLoopNestFunction(int N, int TileSize) {
   auto JitMod = std::make_unique<proteus::JitModule>("host");
-  auto &F = JitMod->addFunction<void, double *, double *>("loopnest_1d");
+  auto &F = JitMod->addFunction<void(double *, double *)>("loopnest_1d");
 
   auto &I = F.declVar<int>("i");
   auto &IncOne = F.declVar<int>("inc");
@@ -43,7 +43,7 @@ static auto get1DLoopNestFunction(int N, int TileSize) {
 
 static auto get1DSimpleLoopNestFunction(int N) {
   auto JitMod = std::make_unique<proteus::JitModule>("host");
-  auto &F = JitMod->addFunction<void, double *, double *>("loopnest_1d_simple");
+  auto &F = JitMod->addFunction<void(double *, double *)>("loopnest_1d_simple");
 
   auto &I = F.declVar<int>("i");
   auto &IncOne = F.declVar<int>("inc");

--- a/tests/frontend/cpu/loopnest_3d.cpp
+++ b/tests/frontend/cpu/loopnest_3d.cpp
@@ -13,7 +13,7 @@
 static auto get3DLoopNestFunction(int DI, int DJ, int DK, int TileI, int TileJ,
                                   int TileK) {
   auto JitMod = std::make_unique<proteus::JitModule>("host");
-  auto &F = JitMod->addFunction<void, double *, double *>("loopnest_3d");
+  auto &F = JitMod->addFunction<void(double *, double *)>("loopnest_3d");
 
   auto &I = F.declVar<int>("i");
   auto &J = F.declVar<int>("j");
@@ -61,7 +61,7 @@ static auto get3DLoopNestFunction(int DI, int DJ, int DK, int TileI, int TileJ,
 static auto get3DUniformTileFunction(int DI, int DJ, int DK, int TileSize) {
   auto JitMod = std::make_unique<proteus::JitModule>("host");
   auto &F =
-      JitMod->addFunction<void, double *, double *>("loopnest_3d_uniform");
+      JitMod->addFunction<void(double *, double *)>("loopnest_3d_uniform");
 
   auto &I = F.declVar<int>("i");
   auto &J = F.declVar<int>("j");

--- a/tests/frontend/cpu/loopnest_3d_uniformtile.cpp
+++ b/tests/frontend/cpu/loopnest_3d_uniformtile.cpp
@@ -13,7 +13,7 @@
 
 static auto get3DUniformTileFunction(int DI, int DJ, int DK, int Tile) {
   auto JitMod = std::make_unique<proteus::JitModule>("host");
-  auto &F = JitMod->addFunction<void, double *>("loopnest_3d_uniformtile");
+  auto &F = JitMod->addFunction<void(double *)>("loopnest_3d_uniformtile");
 
   auto &I = F.declVar<int>("i");
   auto &J = F.declVar<int>("j");

--- a/tests/frontend/cpu/min.cpp
+++ b/tests/frontend/cpu/min.cpp
@@ -17,8 +17,7 @@ int main() {
   proteus::init();
 
   auto J = JitModule();
-  auto &F = J.addFunction<void, float *, float *, float *, int *, int *, int *>(
-      "min_test");
+  auto &F = J.addFunction<void(float *, float *, float *, int *, int *, int *)>("min_test");
 
   auto &Ff0 = F.getArg(0);
   auto &Ff1 = F.getArg(1);

--- a/tests/frontend/cpu/min.cpp
+++ b/tests/frontend/cpu/min.cpp
@@ -17,7 +17,8 @@ int main() {
   proteus::init();
 
   auto J = JitModule();
-  auto &F = J.addFunction<void(float *, float *, float *, int *, int *, int *)>("min_test");
+  auto &F = J.addFunction<void(float *, float *, float *, int *, int *, int *)>(
+      "min_test");
 
   auto &Ff0 = F.getArg(0);
   auto &Ff1 = F.getArg(1);

--- a/tests/frontend/cpu/multi_module.cpp
+++ b/tests/frontend/cpu/multi_module.cpp
@@ -14,7 +14,7 @@ using namespace proteus;
 auto createJitModule1() {
   auto J = std::make_unique<JitModule>("host");
 
-  auto &F1 = J->addFunction<void, double *>("f1");
+  auto &F1 = J->addFunction<void(double *)>("f1");
   {
     F1.beginFunction();
     {
@@ -26,7 +26,7 @@ auto createJitModule1() {
     F1.endFunction();
   }
 
-  auto &F2 = J->addFunction<void, double *>("f2");
+  auto &F2 = J->addFunction<void(double *)>("f2");
   {
 
     F2.beginFunction();
@@ -45,7 +45,7 @@ auto createJitModule1() {
 auto createJitModule2() {
   auto J = std::make_unique<JitModule>("host");
 
-  auto &F1 = J->addFunction<void, double *>("f1");
+  auto &F1 = J->addFunction<void(double *)>("f1");
   {
     F1.beginFunction();
     {
@@ -57,7 +57,7 @@ auto createJitModule2() {
     F1.endFunction();
   }
 
-  auto &F2 = J->addFunction<void, double *>("f2");
+  auto &F2 = J->addFunction<void(double *)>("f2");
   {
     F2.beginFunction();
     {

--- a/tests/frontend/cpu/operators.cpp
+++ b/tests/frontend/cpu/operators.cpp
@@ -15,9 +15,9 @@ int main() {
   proteus::init();
 
   auto J = proteus::JitModule();
-  auto &F = J.addFunction<void(double *, double *, double *, double *,
-                          double *, double *, double *, double *, double *,
-                          double *, double *, double *)>("operators");
+  auto &F = J.addFunction<void(double *, double *, double *, double *, double *,
+                               double *, double *, double *, double *, double *,
+                               double *, double *)>("operators");
   auto &Arg0 = F.getArg(0);
   auto &Arg1 = F.getArg(1);
   auto &Arg2 = F.getArg(2);

--- a/tests/frontend/cpu/operators.cpp
+++ b/tests/frontend/cpu/operators.cpp
@@ -15,9 +15,9 @@ int main() {
   proteus::init();
 
   auto J = proteus::JitModule();
-  auto &F = J.addFunction<void, double *, double *, double *, double *,
+  auto &F = J.addFunction<void(double *, double *, double *, double *,
                           double *, double *, double *, double *, double *,
-                          double *, double *, double *>("operators");
+                          double *, double *, double *)>("operators");
   auto &Arg0 = F.getArg(0);
   auto &Arg1 = F.getArg(1);
   auto &Arg2 = F.getArg(2);

--- a/tests/frontend/cpu/tiled_matmul.cpp
+++ b/tests/frontend/cpu/tiled_matmul.cpp
@@ -15,7 +15,7 @@
 static auto getTiledMatmulFunction(int N, int TileI, int TileJ, int TileK) {
   auto JitMod = std::make_unique<proteus::JitModule>("host");
   auto &F =
-      JitMod->addFunction<void, double *, double *, double *>("tiled_matmul");
+      JitMod->addFunction<void(double *, double *, double *)>("tiled_matmul");
   {
 
     auto Args = F.getArgs();

--- a/tests/frontend/cpu/tiled_transpose.cpp
+++ b/tests/frontend/cpu/tiled_transpose.cpp
@@ -17,8 +17,7 @@
 static auto getTiled2DTransposeFunction(int ROWS, int COLS, int TileSize) {
   auto JitMod = std::make_unique<proteus::JitModule>("host");
   static int Counter = 0;
-  auto &F = JitMod->addFunction<void, double *, double *>(
-      "tiled_transpose_" + std::to_string(Counter++));
+  auto &F = JitMod->addFunction<void(double *, double *)>("tiled_transpose_" + std::to_string(Counter++));
 
   auto &I = F.declVar<int>("i");
   auto &J = F.declVar<int>("j");

--- a/tests/frontend/cpu/tiled_transpose.cpp
+++ b/tests/frontend/cpu/tiled_transpose.cpp
@@ -17,7 +17,8 @@
 static auto getTiled2DTransposeFunction(int ROWS, int COLS, int TileSize) {
   auto JitMod = std::make_unique<proteus::JitModule>("host");
   static int Counter = 0;
-  auto &F = JitMod->addFunction<void(double *, double *)>("tiled_transpose_" + std::to_string(Counter++));
+  auto &F = JitMod->addFunction<void(double *, double *)>(
+      "tiled_transpose_" + std::to_string(Counter++));
 
   auto &I = F.declVar<int>("i");
   auto &J = F.declVar<int>("j");

--- a/tests/frontend/gpu/adam.cpp
+++ b/tests/frontend/gpu/adam.cpp
@@ -65,7 +65,8 @@ adam(T *__restrict__ p, T *__restrict__ m, T *__restrict__ v,
 auto createJitModule() {
   auto J = std::make_unique<JitModule>(TARGET);
   auto KernelHandle =
-      J->addKernel<void(float *, float *, float *, float *, float, float, float, float, float, int, size_t, int, float)>("adam");
+      J->addKernel<void(float *, float *, float *, float *, float, float, float,
+                        float, float, int, size_t, int, float)>("adam");
   auto &F = KernelHandle.F;
   auto [p, m, v, g, b1, b2, eps, grad_scale, step_size, time_step, vector_size,
         mode, decay] = F.getArgs();

--- a/tests/frontend/gpu/adam.cpp
+++ b/tests/frontend/gpu/adam.cpp
@@ -65,8 +65,7 @@ adam(T *__restrict__ p, T *__restrict__ m, T *__restrict__ v,
 auto createJitModule() {
   auto J = std::make_unique<JitModule>(TARGET);
   auto KernelHandle =
-      J->addKernel<float *, float *, float *, float *, float, float, float,
-                   float, float, int, size_t, int, float>("adam");
+      J->addKernel<void(float *, float *, float *, float *, float, float, float, float, float, int, size_t, int, float)>("adam");
   auto &F = KernelHandle.F;
   auto [p, m, v, g, b1, b2, eps, grad_scale, step_size, time_step, vector_size,
         mode, decay] = F.getArgs();

--- a/tests/frontend/gpu/adam_runconst.cpp
+++ b/tests/frontend/gpu/adam_runconst.cpp
@@ -66,7 +66,8 @@ auto createJitModuleSpecial(float _b1, float _b2, float _eps, float _grad_scale,
                             float _step_size, int _time_step,
                             size_t _vector_size, int _mode, float _decay) {
   auto J = std::make_unique<JitModule>(TARGET);
-  auto KernelHandle = J->addKernel<void(float *, float *, float *, float *)>("adam");
+  auto KernelHandle =
+      J->addKernel<void(float *, float *, float *, float *)>("adam");
   auto &F = KernelHandle.F;
   auto [p, m, v, g] = F.getArgs();
 

--- a/tests/frontend/gpu/adam_runconst.cpp
+++ b/tests/frontend/gpu/adam_runconst.cpp
@@ -66,7 +66,7 @@ auto createJitModuleSpecial(float _b1, float _b2, float _eps, float _grad_scale,
                             float _step_size, int _time_step,
                             size_t _vector_size, int _mode, float _decay) {
   auto J = std::make_unique<JitModule>(TARGET);
-  auto KernelHandle = J->addKernel<float *, float *, float *, float *>("adam");
+  auto KernelHandle = J->addKernel<void(float *, float *, float *, float *)>("adam");
   auto &F = KernelHandle.F;
   auto [p, m, v, g] = F.getArgs();
 

--- a/tests/frontend/gpu/add_vectors.cpp
+++ b/tests/frontend/gpu/add_vectors.cpp
@@ -28,7 +28,8 @@ int main() {
 
   // Add a kernel with the signature: void add_vectors(double *A, double *B,
   // size_t N)
-  auto KernelHandle = J.addKernel<void(double *, double *, size_t)>("add_vectors");
+  auto KernelHandle =
+      J.addKernel<void(double *, double *, size_t)>("add_vectors");
   auto &F = KernelHandle.F;
 
   // Begin the function body.

--- a/tests/frontend/gpu/add_vectors.cpp
+++ b/tests/frontend/gpu/add_vectors.cpp
@@ -28,7 +28,7 @@ int main() {
 
   // Add a kernel with the signature: void add_vectors(double *A, double *B,
   // size_t N)
-  auto KernelHandle = J.addKernel<double *, double *, size_t>("add_vectors");
+  auto KernelHandle = J.addKernel<void(double *, double *, size_t)>("add_vectors");
   auto &F = KernelHandle.F;
 
   // Begin the function body.

--- a/tests/frontend/gpu/add_vectors_runconst.cpp
+++ b/tests/frontend/gpu/add_vectors_runconst.cpp
@@ -28,7 +28,7 @@ auto createJitKernel(size_t N) {
 
   // Add a kernel with the signature: void add_vectors(double *A, double *B)
   // using vector_size N as a runtime constant.
-  auto KernelHandle = J->addKernel<double *, double *>("add_vectors");
+  auto KernelHandle = J->addKernel<void(double *, double *)>("add_vectors");
   auto &F = KernelHandle.F;
 
   // Begin the function body.

--- a/tests/frontend/gpu/floydwarshall.cpp
+++ b/tests/frontend/gpu/floydwarshall.cpp
@@ -80,7 +80,7 @@ __global__ void floydWarshallPass(unsigned int *__restrict__ pathDistanceBuffer,
 auto createJitModuleSpecial(unsigned int _numNodes) {
   auto J = std::make_unique<JitModule>(TARGET);
   auto KernelHandle =
-      J->addKernel<unsigned int *, unsigned int *, unsigned int, unsigned int>(
+      J->addKernel<void(unsigned int *, unsigned int *, unsigned int, unsigned int)>(
           "floydWarshallPass");
   auto &F = KernelHandle.F;
   auto [pathDistanceBuffer, pathBuffer, numNodes, pass] = F.getArgs();

--- a/tests/frontend/gpu/floydwarshall.cpp
+++ b/tests/frontend/gpu/floydwarshall.cpp
@@ -80,8 +80,8 @@ __global__ void floydWarshallPass(unsigned int *__restrict__ pathDistanceBuffer,
 auto createJitModuleSpecial(unsigned int _numNodes) {
   auto J = std::make_unique<JitModule>(TARGET);
   auto KernelHandle =
-      J->addKernel<void(unsigned int *, unsigned int *, unsigned int, unsigned int)>(
-          "floydWarshallPass");
+      J->addKernel<void(unsigned int *, unsigned int *, unsigned int,
+                        unsigned int)>("floydWarshallPass");
   auto &F = KernelHandle.F;
   auto [pathDistanceBuffer, pathBuffer, numNodes, pass] = F.getArgs();
 

--- a/tests/frontend/gpu/for.cpp
+++ b/tests/frontend/gpu/for.cpp
@@ -26,7 +26,7 @@ int main() {
   proteus::init();
 
   auto J = proteus::JitModule(TARGET);
-  auto KernelHandle = J.addKernel<double *>("for");
+  auto KernelHandle = J.addKernel<void(double *)>("for");
   auto &F = KernelHandle.F;
 
   auto &I = F.declVar<int>("i");

--- a/tests/frontend/gpu/if.cpp
+++ b/tests/frontend/gpu/if.cpp
@@ -25,7 +25,7 @@ int main() {
   proteus::init();
 
   auto J = proteus::JitModule(TARGET);
-  auto KernelHandleLT = J.addKernel<double, double, double *>("if_lt");
+  auto KernelHandleLT = J.addKernel<void(double, double, double *)>("if_lt");
   auto &LT = KernelHandleLT.F;
   {
     auto &Arg0 = LT.getArg(0);
@@ -43,7 +43,7 @@ int main() {
     LT.endFunction();
   }
 
-  auto KernelHandleLE = J.addKernel<double, double, double *>("if_le");
+  auto KernelHandleLE = J.addKernel<void(double, double, double *)>("if_le");
   auto &LE = KernelHandleLE.F;
   {
     auto &Arg0 = LE.getArg(0);
@@ -61,7 +61,7 @@ int main() {
     LE.endFunction();
   }
 
-  auto KernelHandleGT = J.addKernel<double, double, double *>("if_gt");
+  auto KernelHandleGT = J.addKernel<void(double, double, double *)>("if_gt");
   auto &GT = KernelHandleGT.F;
   {
     auto &Arg0 = GT.getArg(0);
@@ -79,7 +79,7 @@ int main() {
     GT.endFunction();
   }
 
-  auto KernelHandleGE = J.addKernel<double, double, double *>("if_ge");
+  auto KernelHandleGE = J.addKernel<void(double, double, double *)>("if_ge");
   auto &GE = KernelHandleGE.F;
   {
     auto &Arg0 = GE.getArg(0);
@@ -97,7 +97,7 @@ int main() {
     GE.endFunction();
   }
 
-  auto KernelHandleEQ = J.addKernel<double, double, double *>("if_eq");
+  auto KernelHandleEQ = J.addKernel<void(double, double, double *)>("if_eq");
   auto &EQ = KernelHandleEQ.F;
   {
     auto &Arg0 = EQ.getArg(0);
@@ -115,7 +115,7 @@ int main() {
     EQ.endFunction();
   }
 
-  auto KernelHandleNE = J.addKernel<double, double, double *>("if_ne");
+  auto KernelHandleNE = J.addKernel<void(double, double, double *)>("if_ne");
   auto &NE = KernelHandleNE.F;
   {
     auto &Arg0 = NE.getArg(0);

--- a/tests/frontend/gpu/internal_call.cpp
+++ b/tests/frontend/gpu/internal_call.cpp
@@ -36,7 +36,7 @@ auto createJitModule1() {
 
       Var &X = F.defVar<double>(21);
       Var &C = F.call<double>("f2");
-      Var &Res = F.call<double, double, double>("f3", {X, C});
+      Var &Res = F.call<double, double, double>("f3", X, C);
       V[0] = Res;
 
       F.ret();

--- a/tests/frontend/gpu/internal_call.cpp
+++ b/tests/frontend/gpu/internal_call.cpp
@@ -34,8 +34,10 @@ auto createJitModule1() {
     {
       auto [V] = F.getArgs();
 
-      Var &Ret = F.call<double>("foo");
-      V[0] = Ret;
+      Var &X = F.defVar<double>(21);
+      Var &C = F.call<double>("f2");
+      Var &Res = F.call<double>("f3", X, C);
+      V[0] = Res;
 
       F.ret();
     }
@@ -43,13 +45,23 @@ auto createJitModule1() {
   }
 
   {
-    auto &F = J->addFunction<double>("foo");
+    auto &F = J->addFunction<double>("f2");
     F.beginFunction();
     {
-      Var &V = F.declVar<double>();
-      V = 42;
+      Var &C = F.defVar<double>(2.0);
+      F.ret(C);
+    }
+    F.endFunction();
+  }
 
-      F.ret(V);
+  {
+    auto &F = J->addFunction<double, double, double>("f3");
+    F.beginFunction();
+    {
+      auto [X, C] = F.getArgs();
+      Var &P = F.declVar<double>();
+      P = X * C;
+      F.ret(P);
     }
     F.endFunction();
   }

--- a/tests/frontend/gpu/internal_call.cpp
+++ b/tests/frontend/gpu/internal_call.cpp
@@ -35,8 +35,8 @@ auto createJitModule1() {
       auto [V] = F.getArgs();
 
       Var &X = F.defVar<double>(21);
-      Var &C = F.call<double>("f2");
-      Var &Res = F.call<double, double, double>("f3", X, C);
+      Var &C = F.call<double(void)>("f2");
+      Var &Res = F.call<double(double, double)>("f3", X, C);
       V[0] = Res;
 
       F.ret();

--- a/tests/frontend/gpu/internal_call.cpp
+++ b/tests/frontend/gpu/internal_call.cpp
@@ -27,7 +27,7 @@ using namespace proteus;
 auto createJitModule1() {
   auto J = std::make_unique<JitModule>(TARGET);
 
-  auto KernelHandle = J->addKernel<double *>("kernel");
+  auto KernelHandle = J->addKernel<void(double *)>("kernel");
   {
     auto &F = KernelHandle.F;
     F.beginFunction();
@@ -45,7 +45,7 @@ auto createJitModule1() {
   }
 
   {
-    auto &F = J->addFunction<double>("f2");
+    auto &F = J->addFunction<double(void)>("f2");
     F.beginFunction();
     {
       Var &C = F.defVar<double>(2.0);
@@ -55,7 +55,7 @@ auto createJitModule1() {
   }
 
   {
-    auto &F = J->addFunction<double, double, double>("f3");
+    auto &F = J->addFunction<double(double, double)>("f3");
     F.beginFunction();
     {
       auto [X, C] = F.getArgs();

--- a/tests/frontend/gpu/internal_call.cpp
+++ b/tests/frontend/gpu/internal_call.cpp
@@ -36,7 +36,7 @@ auto createJitModule1() {
 
       Var &X = F.defVar<double>(21);
       Var &C = F.call<double>("f2");
-      Var &Res = F.call<double>("f3", X, C);
+      Var &Res = F.call<double, double, double>("f3", {X, C});
       V[0] = Res;
 
       F.ret();

--- a/tests/frontend/gpu/kernel_2d.cpp
+++ b/tests/frontend/gpu/kernel_2d.cpp
@@ -26,8 +26,9 @@ using namespace builtins::gpu;
 int main() {
   auto J = proteus::JitModule(TARGET);
 
-  auto KernelHandle = J.addKernel<void(double *, double *, double *, size_t, size_t)>(
-      "matrix_add_2d");
+  auto KernelHandle =
+      J.addKernel<void(double *, double *, double *, size_t, size_t)>(
+          "matrix_add_2d");
   auto &F = KernelHandle.F;
 
   F.beginFunction();

--- a/tests/frontend/gpu/kernel_2d.cpp
+++ b/tests/frontend/gpu/kernel_2d.cpp
@@ -26,7 +26,7 @@ using namespace builtins::gpu;
 int main() {
   auto J = proteus::JitModule(TARGET);
 
-  auto KernelHandle = J.addKernel<double *, double *, double *, size_t, size_t>(
+  auto KernelHandle = J.addKernel<void(double *, double *, double *, size_t, size_t)>(
       "matrix_add_2d");
   auto &F = KernelHandle.F;
 

--- a/tests/frontend/gpu/kernel_3d.cpp
+++ b/tests/frontend/gpu/kernel_3d.cpp
@@ -26,7 +26,7 @@ int main() {
   auto J = proteus::JitModule(TARGET);
 
   auto KernelHandle =
-      J.addKernel<double *, double *, double *, size_t, size_t, size_t>(
+      J.addKernel<void(double *, double *, double *, size_t, size_t, size_t)>(
           "volume_add_3d");
   auto &F = KernelHandle.F;
 

--- a/tests/frontend/gpu/multi_module.cpp
+++ b/tests/frontend/gpu/multi_module.cpp
@@ -27,7 +27,7 @@ using namespace proteus;
 auto createJitModule1() {
   auto J = std::make_unique<JitModule>(TARGET);
 
-  auto KernelHandle1 = J->addKernel<double *>("kernel1");
+  auto KernelHandle1 = J->addKernel<void(double *)>("kernel1");
   {
     auto &F = KernelHandle1.F;
 
@@ -41,7 +41,7 @@ auto createJitModule1() {
     F.endFunction();
   }
 
-  auto KernelHandle2 = J->addKernel<double *>("kernel2");
+  auto KernelHandle2 = J->addKernel<void(double *)>("kernel2");
   {
     auto &F = KernelHandle2.F;
 
@@ -61,7 +61,7 @@ auto createJitModule1() {
 auto createJitModule2() {
   auto J = std::make_unique<JitModule>(TARGET);
 
-  auto KernelHandle1 = J->addKernel<double *>("kernel1");
+  auto KernelHandle1 = J->addKernel<void(double *)>("kernel1");
   {
     auto &F = KernelHandle1.F;
 
@@ -75,7 +75,7 @@ auto createJitModule2() {
     F.endFunction();
   }
 
-  auto KernelHandle2 = J->addKernel<double *>("kernel2");
+  auto KernelHandle2 = J->addKernel<void(double *)>("kernel2");
   {
     auto &F = KernelHandle2.F;
 

--- a/tests/frontend/gpu/operators.cpp
+++ b/tests/frontend/gpu/operators.cpp
@@ -26,8 +26,7 @@ int main() {
 
   auto J = proteus::JitModule(TARGET);
   auto KernelHandle =
-      J.addKernel<double *, double *, double *, double *, double *, double *,
-                  double *, double *, double *, double *>("operators");
+      J.addKernel<void(double *, double *, double *, double *, double *, double *, double *, double *, double *, double *)>("operators");
   auto &F = KernelHandle.F;
   auto &Arg0 = F.getArg(0);
   auto &Arg1 = F.getArg(1);

--- a/tests/frontend/gpu/operators.cpp
+++ b/tests/frontend/gpu/operators.cpp
@@ -26,7 +26,9 @@ int main() {
 
   auto J = proteus::JitModule(TARGET);
   auto KernelHandle =
-      J.addKernel<void(double *, double *, double *, double *, double *, double *, double *, double *, double *, double *)>("operators");
+      J.addKernel<void(double *, double *, double *, double *, double *,
+                       double *, double *, double *, double *, double *)>(
+          "operators");
   auto &F = KernelHandle.F;
   auto &Arg0 = F.getArg(0);
   auto &Arg1 = F.getArg(1);

--- a/tests/frontend/gpu/shared_memory.cpp
+++ b/tests/frontend/gpu/shared_memory.cpp
@@ -27,7 +27,7 @@ constexpr unsigned WarpSize = 32;
 int main() {
   auto J = proteus::JitModule(TARGET);
 
-  auto KernelHandle = J.addKernel<double *>("shared_reverse_warp");
+  auto KernelHandle = J.addKernel<void(double *)>("shared_reverse_warp");
   auto &F = KernelHandle.F;
 
   F.beginFunction();


### PR DESCRIPTION
This PR adds function arguments to PJ-DSL for external and internal functions. It also brings PJ-DSL `addFunction`/`addKernel` syntax in line with CPPJitModule.
```c++
auto &F = J->addFunction<void(int)>("function");
...
auto &V3 = F.call<int(int, int)>("add", V1, V2);
```

The function's signature is repeated at callsites so internal/external functions maintain the same interface.