### PR TITLE
Set LLVM_DIR to real path

### DIFF
--- a/cmake/SetupLLVM.cmake
+++ b/cmake/SetupLLVM.cmake
@@ -3,9 +3,9 @@
 list(APPEND CMAKE_PREFIX_PATH "${LLVM_INSTALL_DIR}/lib/cmake/llvm/")
 list(APPEND CMAKE_PREFIX_PATH "${LLVM_INSTALL_DIR}/lib/cmake/clang/")
 set(LLVM_DIR "${LLVM_INSTALL_DIR}/lib/cmake/llvm")
-get_filename_component(LLVM_DIR "${LLVM_DIR}" REALPATH)
+file(REAL_PATH "${LLVM_DIR}" LLVM_DIR)
 set(Clang_DIR "${LLVM_INSTALL_DIR}/lib/cmake/clang")
-get_filename_component(Clang_DIR "${Clang_DIR}" REALPATH)
+file(REAL_PATH "${Clang_DIR}" Clang_DIR)
 
 find_package(LLVM REQUIRED CONFIG NO_DEFAULT_PATH)
 

--- a/cmake/SetupLLVM.cmake
+++ b/cmake/SetupLLVM.cmake
@@ -3,7 +3,9 @@
 list(APPEND CMAKE_PREFIX_PATH "${LLVM_INSTALL_DIR}/lib/cmake/llvm/")
 list(APPEND CMAKE_PREFIX_PATH "${LLVM_INSTALL_DIR}/lib/cmake/clang/")
 set(LLVM_DIR "${LLVM_INSTALL_DIR}/lib/cmake/llvm")
+get_filename_component(LLVM_DIR "${LLVM_DIR}" REALPATH)
 set(Clang_DIR "${LLVM_INSTALL_DIR}/lib/cmake/clang")
+get_filename_component(Clang_DIR "${Clang_DIR}" REALPATH)
 
 find_package(LLVM REQUIRED CONFIG NO_DEFAULT_PATH)
 

--- a/cmake/proteusConfig.cmake.in
+++ b/cmake/proteusConfig.cmake.in
@@ -4,7 +4,7 @@ include(CMakeFindDependencyMacro)
 set(PROTEUS_LLVM_DIR "@LLVM_DIR@")
 find_dependency(LLVM REQUIRED CONFIG)
 
-get_filename_component(LLVM_DIR "${LLVM_DIR}" REALPATH)
+file(REAL_PATH "${LLVM_DIR}" LLVM_DIR)
 
 if (NOT "${LLVM_DIR}" STREQUAL "${PROTEUS_LLVM_DIR}")
     message(FATAL_ERROR "Mismatch between target LLVM_DIR = ${LLVM_DIR} "

--- a/cmake/proteusConfig.cmake.in
+++ b/cmake/proteusConfig.cmake.in
@@ -4,6 +4,8 @@ include(CMakeFindDependencyMacro)
 set(PROTEUS_LLVM_DIR "@LLVM_DIR@")
 find_dependency(LLVM REQUIRED CONFIG)
 
+get_filename_component(LLVM_DIR "${LLVM_DIR}" REALPATH)
+
 if (NOT "${LLVM_DIR}" STREQUAL "${PROTEUS_LLVM_DIR}")
     message(FATAL_ERROR "Mismatch between target LLVM_DIR = ${LLVM_DIR} "
     "and Proteus LLVM_DIR = ${PROTEUS_LLVM_DIR}. "

--- a/tests/integration/hip/ci-test-integration.sh
+++ b/tests/integration/hip/ci-test-integration.sh
@@ -11,7 +11,7 @@ if [ -z "${PROTEUS_CI_ROCM_VERSION}" ]; then
 fi
 echo "PROTEUS_CI_ROCM_VERSION ${PROTEUS_CI_ROCM_VERSION}"
 
-export LLVM_INSTALL_DIR=${ROCM_PATH}/llvm
+export LLVM_INSTALL_DIR=$(realpath ${ROCM_PATH}/llvm)
 if [ -z "${LLVM_INSTALL_DIR}" ]; then
     echo "Expected non-empty LLVM_INSTALL_DIR env var"
     exit 1

--- a/tests/integration/hip/ci-test-integration.sh
+++ b/tests/integration/hip/ci-test-integration.sh
@@ -11,7 +11,7 @@ if [ -z "${PROTEUS_CI_ROCM_VERSION}" ]; then
 fi
 echo "PROTEUS_CI_ROCM_VERSION ${PROTEUS_CI_ROCM_VERSION}"
 
-export LLVM_INSTALL_DIR=$(realpath ${ROCM_PATH}/llvm)
+export LLVM_INSTALL_DIR=${ROCM_PATH}/llvm
 if [ -z "${LLVM_INSTALL_DIR}" ]; then
     echo "Expected non-empty LLVM_INSTALL_DIR env var"
     exit 1


### PR DESCRIPTION
Fixes an issue where CMake reports a mismatch between

    /opt/rocm-6.3.1/llvm/lib/cmake/llvm
    /opt/rocm-6.3.1/llvm//lib/cmake/llvm

Although these point to the same directory, the redundant "//"
causes Proteus to treat them as different. This patch normalizes
LLVM_DIR paths before comparison.

Note: /opt/rocm-6.3.1/llvm is a symlink to /opt/rocm-6.3.1/lib/llvm,
so projects that integrate with Proteus (e.g. Mneme) must also
resolve LLVM_DIR consistently.