### PR TITLE
PJ-DSL: Fix operator bugs

### DIFF
--- a/src/lib/Frontend/Var.cpp
+++ b/src/lib/Frontend/Var.cpp
@@ -145,7 +145,7 @@ Var::operator-=(const T &ConstValue) {
   Var &Tmp = Fn.declVarInternal("tmp.", TypeMap<T>::get(Ctx));
   Tmp = ConstValue;
 
-  *this += Tmp;
+  *this -= Tmp;
 
   return *this;
 }
@@ -390,7 +390,7 @@ Var::operator<=(const T &ConstValue) const {
   Var &Tmp = Fn.declVarInternal("cmp.", TypeMap<T>::get(Ctx));
   Tmp = ConstValue;
 
-  return ((*this) < Tmp);
+  return ((*this) <= Tmp);
 }
 
 template <typename T>

--- a/tests/frontend/cpu/operators.cpp
+++ b/tests/frontend/cpu/operators.cpp
@@ -15,9 +15,10 @@ int main() {
   proteus::init();
 
   auto J = proteus::JitModule();
-  auto &F = J.addFunction<void(double *, double *, double *, double *, double *,
-                               double *, double *, double *, double *, double *,
-                               double *, double *, double *, double *)>("operators");
+  auto &F =
+      J.addFunction<void(double *, double *, double *, double *, double *,
+                         double *, double *, double *, double *, double *,
+                         double *, double *, double *, double *)>("operators");
   auto &Arg0 = F.getArg(0);
   auto &Arg1 = F.getArg(1);
   auto &Arg2 = F.getArg(2);
@@ -58,7 +59,7 @@ int main() {
     auto &Cmp = F.declVar<double>("cmp");
     Cmp = 5.0;
     F.beginIf(Cmp <= 5.0);
-    { Arg13[0] = 1.0; } 
+    { Arg13[0] = 1.0; }
     F.endIf();
 
     F.ret();

--- a/tests/frontend/cpu/operators.cpp
+++ b/tests/frontend/cpu/operators.cpp
@@ -17,7 +17,7 @@ int main() {
   auto J = proteus::JitModule();
   auto &F = J.addFunction<void(double *, double *, double *, double *, double *,
                                double *, double *, double *, double *, double *,
-                               double *, double *)>("operators");
+                               double *, double *, double *, double *)>("operators");
   auto &Arg0 = F.getArg(0);
   auto &Arg1 = F.getArg(1);
   auto &Arg2 = F.getArg(2);
@@ -30,6 +30,8 @@ int main() {
   auto &Arg9 = F.getArg(9);
   auto &Arg10 = F.getArg(10);
   auto &Arg11 = F.getArg(11);
+  auto &Arg12 = F.getArg(12);
+  auto &Arg13 = F.getArg(13);
   F.beginFunction();
   {
     Arg0[0] = 2;
@@ -50,14 +52,23 @@ int main() {
     Arg10[0] = Arg0 % Arg1;
     Arg11[0] %= Arg0[0];
 
+    Arg12[0] = 10.0;
+    Arg12[0] -= 3.0;
+
+    auto &Cmp = F.declVar<double>("cmp");
+    Cmp = 5.0;
+    F.beginIf(Cmp <= 5.0);
+    { Arg13[0] = 1.0; } 
+    F.endIf();
+
     F.ret();
   }
   F.endFunction();
 
   J.compile();
 
-  double R0, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11;
-  F(&R0, &R1, &R2, &R3, &R4, &R5, &R6, &R7, &R8, &R9, &R10, &R11);
+  double R0, R1, R2, R3, R4, R5, R6, R7, R8, R9, R10, R11, R12, R13 = 0.0;
+  F(&R0, &R1, &R2, &R3, &R4, &R5, &R6, &R7, &R8, &R9, &R10, &R11, &R12, &R13);
 
   std::cout << "R0 = " << R0 << "\n";
   std::cout << "R1 = " << R1 << "\n";
@@ -71,6 +82,8 @@ int main() {
   std::cout << "R9 = " << R9 << "\n";
   std::cout << "R10 = " << R10 << "\n";
   std::cout << "R11 = " << R11 << "\n";
+  std::cout << "R12 = " << R12 << "\n";
+  std::cout << "R13 = " << R13 << "\n";
 
   proteus::finalize();
   return 0;
@@ -89,5 +102,7 @@ int main() {
 // CHECK-NEXT: R9 = 2.5
 // CHECK-NEXT: R10 = 2
 // CHECK-NEXT: R11 = 1
+// CHECK-NEXT: R12 = 7
+// CHECK-NEXT: R13 = 1
 // CHECK-FIRST: JitStorageCache hits 0 total 1
 // CHECK-SECOND: JitStorageCache hits 1 total 1

--- a/tests/frontend/gpu/operators.cpp
+++ b/tests/frontend/gpu/operators.cpp
@@ -27,8 +27,8 @@ int main() {
   auto J = proteus::JitModule(TARGET);
   auto KernelHandle =
       J.addKernel<void(double *, double *, double *, double *, double *,
-                       double *, double *, double *, double *, double *)>(
-          "operators");
+                       double *, double *, double *, double *, double *,
+                       double *, double *)>("operators");
   auto &F = KernelHandle.F;
   auto &Arg0 = F.getArg(0);
   auto &Arg1 = F.getArg(1);
@@ -40,6 +40,8 @@ int main() {
   auto &Arg7 = F.getArg(7);
   auto &Arg8 = F.getArg(8);
   auto &Arg9 = F.getArg(9);
+  auto &Arg10 = F.getArg(10);
+  auto &Arg11 = F.getArg(11);
   F.beginFunction();
   {
     Arg0[0] = 2;
@@ -57,13 +59,23 @@ int main() {
     Arg8[0] *= Arg0[0];
     Arg9[0] /= Arg0[0];
 
+    Arg10[0] = 10.0;
+    Arg10[0] -= 3.0;
+
+    auto &Cmp = F.declVar<double>("cmp");
+    Cmp = 5.0;
+    Arg11[0] = 0.0;
+    F.beginIf(Cmp <= 5.0);
+    { Arg11[0] = 1.0; }
+    F.endIf();
+
     F.ret();
   }
   F.endFunction();
 
   J.compile();
 
-  double *R0, *R1, *R2, *R3, *R4, *R5, *R6, *R7, *R8, *R9;
+  double *R0, *R1, *R2, *R3, *R4, *R5, *R6, *R7, *R8, *R9, *R10, *R11;
   gpuErrCheck(gpuMallocManaged(&R0, sizeof(double)));
   gpuErrCheck(gpuMallocManaged(&R1, sizeof(double)));
   gpuErrCheck(gpuMallocManaged(&R2, sizeof(double)));
@@ -74,9 +86,11 @@ int main() {
   gpuErrCheck(gpuMallocManaged(&R7, sizeof(double)));
   gpuErrCheck(gpuMallocManaged(&R8, sizeof(double)));
   gpuErrCheck(gpuMallocManaged(&R9, sizeof(double)));
+  gpuErrCheck(gpuMallocManaged(&R10, sizeof(double)));
+  gpuErrCheck(gpuMallocManaged(&R11, sizeof(double)));
 
   gpuErrCheck(KernelHandle.launch({1, 1, 1}, {1, 1, 1}, 0, nullptr, R0, R1, R2,
-                                  R3, R4, R5, R6, R7, R8, R9));
+                                  R3, R4, R5, R6, R7, R8, R9, R10, R11));
   gpuErrCheck(gpuDeviceSynchronize());
 
   std::cout << "R0 = " << *R0 << "\n";
@@ -89,6 +103,8 @@ int main() {
   std::cout << "R7 = " << *R7 << "\n";
   std::cout << "R8 = " << *R8 << "\n";
   std::cout << "R9 = " << *R9 << "\n";
+  std::cout << "R10 = " << *R10 << "\n";
+  std::cout << "R11 = " << *R11 << "\n";
 
   gpuErrCheck(gpuFree(R0));
   gpuErrCheck(gpuFree(R1));
@@ -100,6 +116,8 @@ int main() {
   gpuErrCheck(gpuFree(R7));
   gpuErrCheck(gpuFree(R8));
   gpuErrCheck(gpuFree(R9));
+  gpuErrCheck(gpuFree(R10));
+  gpuErrCheck(gpuFree(R11));
 
   proteus::finalize();
   return 0;
@@ -116,6 +134,8 @@ int main() {
 // CHECK-NEXT: R7 = 3
 // CHECK-NEXT: R8 = 10
 // CHECK-NEXT: R9 = 2.5
+// CHECK-NEXT: R10 = 7
+// CHECK-NEXT: R11 = 1
 // CHECK-NEXT: JitCache hits 0 total 1
 // CHECK-NEXT: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
 // CHECK-FIRST: JitStorageCache hits 0 total 1

--- a/tests/frontend/gpu/operators.cpp
+++ b/tests/frontend/gpu/operators.cpp
@@ -25,10 +25,9 @@ int main() {
   proteus::init();
 
   auto J = proteus::JitModule(TARGET);
-  auto KernelHandle =
-      J.addKernel<void(double *, double *, double *, double *, double *,
-                       double *, double *, double *, double *, double *,
-                       double *, double *)>("operators");
+  auto KernelHandle = J.addKernel<void(
+      double *, double *, double *, double *, double *, double *, double *,
+      double *, double *, double *, double *, double *)>("operators");
   auto &F = KernelHandle.F;
   auto &Arg0 = F.getArg(0);
   auto &Arg1 = F.getArg(1);


### PR DESCRIPTION
The implementations for Var's scalar constant `-=` and `<=` use the wrong operation.
This fixes that and adds tests for these operations; the tests fail without the changes to Var.cpp.