### PR TITLE
Allow proteus pass to be applied on non-annotated codes

### DIFF
--- a/cmake/ProteusFunctions.cmake
+++ b/cmake/ProteusFunctions.cmake
@@ -1,7 +1,20 @@
 function(add_proteus target)
-    target_compile_options(${target} PRIVATE
-        "-fpass-plugin=\$<TARGET_FILE:ProteusPass>"
-    )
+    set(options FORCE_JIT_ANNOTATE_ALL)
+    cmake_parse_arguments(PROTEUS_PASS "${options}" "" "" ${ARGN})
+
+    if (PROTEUS_PASS_FORCE_JIT_ANNOTATE_ALL)
+        target_compile_options(${target} PRIVATE
+            # -fplugin loading is needed to register the plugin command line
+            # option.
+            "-fplugin=$<TARGET_FILE:ProteusPass>"
+            "-fpass-plugin=$<TARGET_FILE:ProteusPass>"
+            "SHELL:-Xclang -mllvm -Xclang -force-proteus-jit-annotate-all"
+        )
+    else()
+        target_compile_options(${target} PRIVATE
+            "-fpass-plugin=\$<TARGET_FILE:ProteusPass>"
+        )
+    endif()
 
     target_link_options(${target} PRIVATE
         "SHELL:\$<\$<LINK_LANGUAGE:HIP>:-Xoffload-linker --load-pass-plugin=\$<TARGET_FILE:ProteusPass>>")

--- a/include/proteus/JitEngineDevice.hpp
+++ b/include/proteus/JitEngineDevice.hpp
@@ -733,6 +733,10 @@ void JitEngineDevice<ImplT>::registerFunction(
     PROTEUS_FATAL_ERROR("Expected Handle in map");
   BinaryInfo &BinInfo = HandleToBinaryInfo[Handle];
 
+  PROTEUS_DBG(Logger::logs("proteus")
+              << "Register function  " << KernelName << " with binary handle "
+              << Handle << "\n");
+
   JITKernelInfoMap[Kernel] =
       JITKernelInfo{Kernel, BinInfo, KernelName, RCInfoArray};
 }

--- a/src/pass/AnnotationHandler.h
+++ b/src/pass/AnnotationHandler.h
@@ -42,7 +42,9 @@ public:
   AnnotationHandler(Module &M);
 
   void
-  parseAnnotations(MapVector<Function *, JitFunctionInfo> &JitFunctionInfoMap);
+  parseAnnotations(MapVector<Function *, JitFunctionInfo> &JitFunctionInfoMap,
+                   const DenseMap<Value *, GlobalVariable *> &StubToKernelMap,
+                   bool ForceJitAnnotateAll);
 
   void parseManifestFileAnnotations(
       const DenseMap<Value *, GlobalVariable *> &StubToKernelMap,
@@ -56,9 +58,8 @@ private:
 
   void appendToGlobalAnnotations(SmallVector<Constant *> &NewAnnotations);
 
-  Constant *
-  createJitAnnotation(Function *F,
-                      SmallSetVector<RuntimeConstantInfo, 16> &ConstantArgs);
+  Constant *createJitAnnotation(
+      Function *F, const SmallSetVector<RuntimeConstantInfo, 16> &ConstantArgs);
 
   void createDeviceManifestFile(
       DenseMap<Function *, SmallSetVector<RuntimeConstantInfo, 16>> &RCInfoMap);

--- a/tests/gpu/CMakeLists.txt
+++ b/tests/gpu/CMakeLists.txt
@@ -169,6 +169,28 @@ function(CREATE_PROTEUS_GPU_LIBRARY lib source)
     endif()
 endfunction()
 
+function(CREATE_GPU_TEST_FORCE exe check_source)
+    CREATE_GPU_TEST(${exe} ${check_source} ${ARGN})
+    # Add flags for forced annotations.
+    target_compile_options(
+        ${exe}.${lang}
+        PUBLIC
+            "-fplugin=$<TARGET_FILE:ProteusPass>"
+            "SHELL:-Xclang -mllvm -Xclang -force-proteus-jit-annotate-all"
+    )
+endfunction()
+
+function(CREATE_GPU_TEST_RDC_FORCE exe check_source)
+    CREATE_GPU_TEST_RDC(${exe} ${check_source} ${ARGN})
+    # Add flags for forced annotations.
+    target_compile_options(
+        ${exe}.${lang}.rdc
+        PUBLIC
+            "-fplugin=$<TARGET_FILE:ProteusPass>"
+            "SHELL:-Xclang -mllvm -Xclang -force-proteus-jit-annotate-all"
+    )
+endfunction()
+
 if(PROTEUS_ENABLE_HIP)
     enable_language(HIP)
 elseif(PROTEUS_ENABLE_CUDA)
@@ -271,6 +293,8 @@ CREATE_GPU_TEST(dynamic_jit_array dynamic_jit_array.cpp)
 CREATE_GPU_TEST(jit_struct jit_struct.cpp)
 CREATE_GPU_TEST(kernel_tuning kernel_tuning.cpp)
 
+CREATE_GPU_TEST_FORCE(force_annotations force_annotations.cpp)
+
 CREATE_GPU_TEST_RDC(kernel kernel.cpp)
 CREATE_GPU_TEST_RDC(kernel_pass_pipeline kernel_pass_pipeline.cpp)
 CREATE_GPU_TEST_RDC(kernel_cache kernel_cache.cpp)
@@ -331,6 +355,8 @@ CREATE_GPU_TEST_RDC(types_jit_array types_jit_array.cpp)
 CREATE_GPU_TEST_RDC(dynamic_jit_array dynamic_jit_array.cpp)
 CREATE_GPU_TEST_RDC(jit_struct jit_struct.cpp)
 CREATE_GPU_TEST_RDC(kernel_tuning kernel_tuning.cpp)
+
+CREATE_GPU_TEST_RDC_FORCE(force_annotations force_annotations.cpp)
 
 if(PROTEUS_ENABLE_HIP)
     if(LLVM_VERSION_MAJOR GREATER_EQUAL 18)

--- a/tests/gpu/force_annotations.cpp
+++ b/tests/gpu/force_annotations.cpp
@@ -1,0 +1,59 @@
+// clang-format off
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/force_annotations.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// Second run uses the object cache.
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/force_annotations.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
+// clang-format on
+
+#include <climits>
+#include <cstdio>
+
+#include "gpu_common.h"
+#include <proteus/JitInterface.hpp>
+
+__global__ void kernel1() { printf("Kernel one\n"); }
+
+__device__ int inc(int Item) { return Item + 1; }
+
+template <typename Func> __device__ int foo(Func F, int Item) {
+  return F(Item);
+}
+
+__global__ void kernel2(int Item) {
+  int Ret = foo(inc, Item);
+  printf("Kernel two %d\n", Ret);
+}
+
+__global__ void kernel3() { printf("Kernel three\n"); }
+
+template <typename T> gpuError_t launcher(T KernelIn) {
+  return gpuLaunchKernel((const void *)KernelIn, 1, 1, 0, 0, 0);
+}
+
+int main() {
+  proteus::init();
+
+  kernel1<<<1, 1>>>();
+  gpuErrCheck(gpuDeviceSynchronize());
+
+  kernel2<<<1, 1>>>(1);
+  gpuErrCheck(gpuDeviceSynchronize());
+
+  gpuErrCheck(launcher(kernel3));
+  gpuErrCheck(gpuDeviceSynchronize());
+
+  proteus::finalize();
+  return 0;
+}
+
+// clang-format off
+// CHECK: Kernel one
+// CHECK: Kernel two 2
+// CHECK: Kernel three
+// CHECK: JitCache hits 0 total 3
+// CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
+// CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
+// CHECK: HashValue {{[0-9]+}} NumExecs 1 NumHits 0
+// CHECK-FIRST: JitStorageCache hits 0 total 3
+// CHECK-SECOND: JitStorageCache hits 3 total 3


### PR DESCRIPTION
This PR enhances the Proteus LLVM pass by enabling it to proactively annotate all GPU kernels when the relevant compile-time option is enabled. If the option is disabled, the previous behavior remains unchanged.  

## Motivation
- Proteus can now JIT kernels even when users have not manually inserted annotations, applying custom pipelines in a transparent way.  
- By exposing annotated entries as a **generic LLVM portability layer**, Proteus provides an API to access kernel LLVM IR at runtime.  
- **Mneme** leverages this capability to obtain kernel IR directly from Proteus during execution, eliminating the need to duplicate annotation logic.  

## Benefits
- Reduces code duplication in Mneme by ~1500 LOC.  
- Improves robustness of Mneme’s record/replay pipeline by relying on Proteus’ robust pass infrastructure.  
- Keeps Proteus independent, while allowing downstream tools (like Mneme) to build on its IR access layer.  