### PR TITLE
Frontend/CUDA: Link Only Needed LibDevice Functions

### DIFF
--- a/include/proteus/Frontend/DispatcherCUDA.hpp
+++ b/include/proteus/Frontend/DispatcherCUDA.hpp
@@ -30,7 +30,8 @@ public:
         LibDeviceBuffer->get()->getMemBufferRef(), ModOwner->getContext());
 
     llvm::Linker linker(*ModOwner);
-    linker.linkInModule(std::move(LibDeviceModule.get()));
+    linker.linkInModule(std::move(LibDeviceModule.get()),
+                        llvm::Linker::Flags::LinkOnlyNeeded);
 
     std::unique_ptr<MemoryBuffer> ObjectModule =
         Jit.compileOnly(*ModOwner, DisableIROpt);


### PR DESCRIPTION
O3 optimization and PTX codegen are about 100x slower for CPP/DSL modules than for annotation-based ones.
This is because the entire libdevice is linked into the JIT modules, and GlobalDCE does not eliminate the unused functions.

I found about **160k passes are run for these modules** during O3 optimization, versus about 1600 for annotation modules.

This PR links only the used parts of LibDevice, and brings the runtime of these steps in line with annotation.
Before:
```bash
(proteus_matrix) [fink12@matrix10:attention]$ ./attention-proteus.x 65536 2048 100
[proteus] optimizeIR optlevel 3 codegenopt 3 2.269674e+02 ms
[proteus] Codegen ptx 2.205837e+02 ms
[proteus] Codegen CUDA RTC 1.094178e+02 ms
```

After:
```bash
(proteus_matrix) [fink12@matrix10:attention]$ ./attention-proteus.x 65536 2048 100
[proteus] optimizeIR optlevel 3 codegenopt 3 3.437325e+00 ms
[proteus] Codegen ptx 3.254797e+00 ms
[proteus] Codegen CUDA RTC 6.062908e+01 ms
```