### PR TITLE
[NFC] Make cmake more robust to rocm llvm installations

### DIFF
--- a/cmake/SetupLLVM.cmake
+++ b/cmake/SetupLLVM.cmake
@@ -1,12 +1,22 @@
 # Find LLVM and Clang packages using the specified LLVM installation directory.
 find_package(LLVM REQUIRED CONFIG NO_DEFAULT_PATH
   HINTS "${LLVM_INSTALL_DIR}"
-  PATH_SUFFIXES "lib/cmake/llvm" "lib64/cmake/llvm" "cmake/llvm"
+  PATH_SUFFIXES
+    "lib/cmake/llvm"
+    "lib64/cmake/llvm"
+    "cmake/llvm"
+    "llvm/lib/cmake/llvm"
+    "llvm/lib64/cmake/llvm"
 )
 
 find_package(Clang REQUIRED CONFIG NO_DEFAULT_PATH
   HINTS "${LLVM_INSTALL_DIR}"
-  PATH_SUFFIXES "lib/cmake/clang" "lib64/cmake/clang" "cmake/clang"
+  PATH_SUFFIXES
+    "lib/cmake/clang"
+    "lib64/cmake/clang"
+    "cmake/clang"
+    "llvm/lib/cmake/clang"
+    "llvm/lib64/cmake/clang"
 )
 
 # Canonicalize found paths when LLVM is built with symlinks to have valid error

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -149,9 +149,11 @@ endif()
 
 find_program(CLANGXX
   NAMES clang++
-  PATHS "${LLVM_INSTALL_DIR}/bin"
   NO_DEFAULT_PATH
   REQUIRED
+  PATHS
+    "${LLVM_INSTALL_DIR}/bin"
+    "${LLVM_INSTALL_DIR}/llvm/bin"
 )
 message(STATUS "Found clang++: ${CLANGXX}")
 


### PR DESCRIPTION
- Search more paths when discovering clang++ and Clang, LLVM configs to support the rocm installation directory as the base