### PR TITLE
Fix test for proteusFrontend with a clang plugin

### DIFF
--- a/tests/integration/hip/cmake-clang_plugin-proteusFrontend/CMakeLists.txt
+++ b/tests/integration/hip/cmake-clang_plugin-proteusFrontend/CMakeLists.txt
@@ -19,6 +19,7 @@ target_link_options(main PRIVATE
 set_target_properties(main PROPERTIES INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 # Build the clang plugin library.
+find_package(LLVM REQUIRED CONFIG)
 find_package(Clang REQUIRED CONFIG)
 add_library(ClangPlugin SHARED ClangPlugin.cpp)
 target_include_directories(ClangPlugin PRIVATE "${LLVM_INCLUDE_DIRS};${CLANG_INCLUDE_DIRS}")


### PR DESCRIPTION
- Add Clang and LLVM include directories when building the plugin

Closes #336