### PR TITLE
Make time trace output file configurable

### DIFF
--- a/include/proteus/Config.hpp
+++ b/include/proteus/Config.hpp
@@ -314,7 +314,7 @@ public:
   bool ProteusDebugOutput;
   std::optional<const std::string> ProteusCacheDir;
   std::string ProteusObjectCacheChain;
-  std::optional<std::string> ProteusTimeTraceFile;
+  std::string ProteusTimeTraceFile;
 
   const CodeGenerationConfig &getCGConfig(llvm::StringRef KName = "") const {
 
@@ -370,7 +370,8 @@ private:
     ProteusDebugOutput = getEnvOrDefaultBool("PROTEUS_DEBUG_OUTPUT", false);
     ProteusObjectCacheChain =
         getEnvOrDefaultString("PROTEUS_OBJECT_CACHE_CHAIN").value_or("storage");
-    ProteusTimeTraceFile = getEnvOrDefaultString("PROTEUS_TIME_TRACE_FILE");
+    ProteusTimeTraceFile =
+        getEnvOrDefaultString("PROTEUS_TIME_TRACE_FILE").value_or("");
   }
 };
 } // namespace proteus

--- a/include/proteus/TimeTracing.hpp
+++ b/include/proteus/TimeTracing.hpp
@@ -26,7 +26,7 @@ struct TimeTracerRAII {
 
   ~TimeTracerRAII() {
     auto &OutputFile = Config::get().ProteusTimeTraceFile;
-    if (auto E = timeTraceProfilerWrite(OutputFile.value_or(""), "-")) {
+    if (auto E = timeTraceProfilerWrite(OutputFile, "-")) {
       handleAllErrors(std::move(E));
       return;
     }


### PR DESCRIPTION
The output file from LLVM's `TimeTrace` always goes to `out.time-trace`. This makes that configurable through an environment variable.