### PR TITLE
DSL/CPP: Kernel Launch Using Dim3

### DIFF
--- a/include/proteus/Frontend/Dispatcher.h
+++ b/include/proteus/Frontend/Dispatcher.h
@@ -9,6 +9,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <type_traits>
 
 namespace llvm {
 class LLVMContext;
@@ -18,6 +19,20 @@ class MemoryBuffer;
 
 struct LaunchDims {
   unsigned X = 1, Y = 1, Z = 1;
+
+  constexpr LaunchDims() = default;
+
+  constexpr LaunchDims(unsigned X, unsigned Y = 1, unsigned Z = 1)
+      : X(X), Y(Y), Z(Z) {}
+
+  // Templated converting constructor for dim3-like types.
+  template <
+      typename T,
+      typename = std::enable_if_t<
+          std::is_convertible_v<decltype(std::declval<T>().x), unsigned> &&
+          std::is_convertible_v<decltype(std::declval<T>().y), unsigned> &&
+          std::is_convertible_v<decltype(std::declval<T>().z), unsigned>>>
+  constexpr LaunchDims(const T &Dims) : X(Dims.x), Y(Dims.y), Z(Dims.z) {}
 };
 
 namespace proteus {

--- a/tests/frontend/gpu/cpp_source.cpp
+++ b/tests/frontend/gpu/cpp_source.cpp
@@ -34,12 +34,21 @@ int main() {
 
   CppJitModule CJM{TARGET, Code};
   auto Kernel = CJM.getKernel<void(int)>("foo");
+
+  // Test brace-init syntax.
   Kernel.launch({1, 1, 1}, {1, 1, 1}, 0, nullptr, 42);
+  gpuErrCheck(gpuDeviceSynchronize());
+
+  // Test dim3 implicit conversion.
+  dim3 Grid(1, 1, 1);
+  dim3 Block(1, 1, 1);
+  Kernel.launch(Grid, Block, 0, nullptr, 43);
   gpuErrCheck(gpuDeviceSynchronize());
 }
 
 // clang-format off
 // CHECK: Kernel 42
+// CHECK: Kernel 43
 // CHECK: [proteus][Dispatcher{{CUDA|HIP}}] MemoryCache rank 0 hits 0 accesses 1
 // CHECK: [proteus][Dispatcher{{CUDA|HIP}}] MemoryCache rank 0 HashValue {{[0-9]+}} NumExecs 1 NumHits 0
 // CHECK-FIRST: [proteus][Dispatcher{{CUDA|HIP}}] StorageCache rank 0 hits 0 accesses 1

--- a/tests/frontend/gpu/shared_memory.cpp
+++ b/tests/frontend/gpu/shared_memory.cpp
@@ -70,8 +70,10 @@ int main() {
 
   std::cout << "Launching with NumBlocks " << NumBlocks << " each with "
             << ThreadsPerBlock << " threads...\n";
-  gpuErrCheck(KernelHandle.launch({NumBlocks, 1, 1}, {ThreadsPerBlock, 1, 1}, 0,
-                                  nullptr, A));
+
+  dim3 Grid(NumBlocks, 1, 1);
+  dim3 Block(ThreadsPerBlock, 1, 1);
+  gpuErrCheck(KernelHandle.launch(Grid, Block, 0, nullptr, A));
 
   gpuErrCheck(gpuDeviceSynchronize());
 


### PR DESCRIPTION
Adds constructor to `LaunchDims` for `dim3`-like types to increase compatibility with CUDA/HIP workflows.