### PR TITLE
Link only needed from LLVM and privatize

### DIFF
--- a/include/proteus/Frontend/Dispatcher.h
+++ b/include/proteus/Frontend/Dispatcher.h
@@ -1,6 +1,7 @@
 #ifndef PROTEUS_FRONTEND_DISPATCHER_H
 #define PROTEUS_FRONTEND_DISPATCHER_H
 
+#include "proteus/Error.h"
 #include "proteus/Frontend/TargetModel.h"
 
 #if PROTEUS_ENABLE_HIP && __HIP__
@@ -49,7 +50,6 @@ template <typename R, typename... Args> struct sig_traits<R(Args...)> {
 
 using namespace llvm;
 
-// in Dispatcher.h (or a new Errors.h)
 struct DispatchResult {
   int Ret;
 

--- a/include/proteus/Frontend/TargetModel.h
+++ b/include/proteus/Frontend/TargetModel.h
@@ -1,60 +1,17 @@
 #ifndef PROTEUS_TARGET_MODE_H
 #define PROTEUS_TARGET_MODE_H
 
-#include "proteus/Error.h"
-
-#include <llvm/TargetParser/Host.h>
+#include <string>
 
 namespace proteus {
 
-using namespace llvm;
-
 enum class TargetModelType { HOST, CUDA, HIP, HOST_HIP, HOST_CUDA };
 
-inline TargetModelType parseTargetModel(const std::string &Target) {
-  if (Target == "host" || Target == "native") {
-    return TargetModelType::HOST;
-  }
+TargetModelType parseTargetModel(const std::string &Target);
 
-  if (Target == "cuda") {
-    return TargetModelType::CUDA;
-  }
+std::string getTargetTriple(TargetModelType Model);
 
-  if (Target == "hip") {
-    return TargetModelType::HIP;
-  }
-
-  if (Target == "host_hip") {
-    return TargetModelType::HOST_HIP;
-  }
-
-  if (Target == "host_cuda") {
-    return TargetModelType::HOST_CUDA;
-  }
-
-  reportFatalError("Unsupported target " + Target);
-}
-
-inline std::string getTargetTriple(TargetModelType Model) {
-  switch (Model) {
-  case TargetModelType::HOST_HIP:
-  case TargetModelType::HOST_CUDA:
-  case TargetModelType::HOST:
-    return sys::getProcessTriple();
-  case TargetModelType::CUDA:
-    return "nvptx64-nvidia-cuda";
-  case TargetModelType::HIP:
-    return "amdgcn-amd-amdhsa";
-  default:
-    reportFatalError("Unsupported target model");
-  }
-}
-
-inline bool isHostTargetModel(TargetModelType TargetModel) {
-  return (TargetModel == TargetModelType::HOST) ||
-         (TargetModel == TargetModelType::HOST_HIP) ||
-         (TargetModel == TargetModelType::HOST_CUDA);
-}
+bool isHostTargetModel(TargetModelType TargetModel);
 
 } // namespace proteus
 

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -16,6 +16,7 @@ set(SOURCES
   Frontend/Func.cpp
   Frontend/JitFrontend.cpp
   Frontend/LoopUnroller.cpp
+  Frontend/TargetModel.cpp
   Frontend/TypeMap.cpp
   Frontend/VarStorage.cpp
 )

--- a/src/lib/Frontend/TargetModel.cpp
+++ b/src/lib/Frontend/TargetModel.cpp
@@ -1,0 +1,55 @@
+#include "proteus/Frontend/TargetModel.h"
+#include "proteus/Error.h"
+
+#include <llvm/TargetParser/Host.h>
+
+namespace proteus {
+
+using namespace llvm;
+
+TargetModelType parseTargetModel(const std::string &Target) {
+  if (Target == "host" || Target == "native") {
+    return TargetModelType::HOST;
+  }
+
+  if (Target == "cuda") {
+    return TargetModelType::CUDA;
+  }
+
+  if (Target == "hip") {
+    return TargetModelType::HIP;
+  }
+
+  if (Target == "host_hip") {
+    return TargetModelType::HOST_HIP;
+  }
+
+  if (Target == "host_cuda") {
+    return TargetModelType::HOST_CUDA;
+  }
+
+  reportFatalError("Unsupported target " + Target);
+}
+
+std::string getTargetTriple(TargetModelType Model) {
+  switch (Model) {
+  case TargetModelType::HOST_HIP:
+  case TargetModelType::HOST_CUDA:
+  case TargetModelType::HOST:
+    return sys::getProcessTriple();
+  case TargetModelType::CUDA:
+    return "nvptx64-nvidia-cuda";
+  case TargetModelType::HIP:
+    return "amdgcn-amd-amdhsa";
+  default:
+    reportFatalError("Unsupported target model");
+  }
+}
+
+bool isHostTargetModel(TargetModelType TargetModel) {
+  return (TargetModel == TargetModelType::HOST) ||
+         (TargetModel == TargetModelType::HOST_HIP) ||
+         (TargetModel == TargetModelType::HOST_CUDA);
+}
+
+} // namespace proteus

--- a/tests/frontend/gpu/for.cpp
+++ b/tests/frontend/gpu/for.cpp
@@ -10,7 +10,6 @@
 
 #include <proteus/JitFrontend.h>
 #include <proteus/JitInterface.h>
-#include <proteus/Utils.h>
 
 #include "../../gpu/gpu_common.h"
 

--- a/tests/frontend/gpu/while.cpp
+++ b/tests/frontend/gpu/while.cpp
@@ -11,7 +11,6 @@
 #include <proteus/Frontend/Builtins.h>
 #include <proteus/JitFrontend.h>
 #include <proteus/JitInterface.h>
-#include <proteus/Utils.h>
 
 #include "../../gpu/gpu_common.h"
 


### PR DESCRIPTION
Link only necessary LLVM libraries using `llvm_map_components_to_libnames`.

We should not expose consumers to LLVM library, definitions, or headers.

Closes #359 