### PR TITLE
Add install prefix and hostname to CUDA setup script

### DIFF
--- a/scripts/setup-cuda.sh
+++ b/scripts/setup-cuda.sh
@@ -16,8 +16,15 @@ ml load cuda/${CUDA_VERSION}
 
 export PATH="$LLVM_INSTALL_DIR/bin":$PATH
 
-mkdir build-${HOSTN}-cuda-${CUDA_VERSION}
-pushd build-${HOSTN}-cuda-${CUDA_VERSION}
+LLVM_VERSION=$("$LLVM_INSTALL_DIR/bin/llvm-config" --version)
+if [ -z "${LLVM_VERSION}" ]; then
+    echo "Error: could not determine LLVM version from $LLVM_INSTALL_DIR/bin/llvm-config"
+    return 1
+fi
+
+BUILDDIR="build-${HOSTN}-cuda-${CUDA_VERSION}-llvm-${LLVM_VERSION}"
+mkdir "${BUILDDIR}"
+pushd "${BUILDDIR}"
 
 cmake .. \
 -DLLVM_INSTALL_DIR="$LLVM_INSTALL_DIR" \
@@ -26,7 +33,7 @@ cmake .. \
 -DCMAKE_C_COMPILER="$LLVM_INSTALL_DIR/bin/clang" \
 -DCMAKE_CXX_COMPILER="$LLVM_INSTALL_DIR/bin/clang++" \
 -DCMAKE_CUDA_COMPILER="$LLVM_INSTALL_DIR/bin/clang++" \
--DCMAKE_INSTALL_PREFIX=../install-${HOSTN}-cuda-${CUDA_VERSION} \
+-DCMAKE_INSTALL_PREFIX=../install-${HOSTN}-cuda-${CUDA_VERSION}-llvm-${LLVM_VERSION} \
 -DCMAKE_EXPORT_COMPILE_COMMANDS=on \
 "${@:3}"
 


### PR DESCRIPTION
Align `setup-cuda.sh` with `setup-rocm.sh` conventions.

- Add `HOSTN` variable to strip digits from hostname
- Include hostname in build directory name (`build-${HOSTN}-cuda-${CUDA_VERSION}`)
- Set `CMAKE_INSTALL_PREFIX` to `../install-${HOSTN}-cuda-${CUDA_VERSION}` so `make install` targets a local directory instead of defaulting to `/usr/local`