### PR TITLE
Make saveToFileAtomic safe for multiple MPI cache writers

### DIFF
--- a/src/include/proteus/impl/Utils.h
+++ b/src/include/proteus/impl/Utils.h
@@ -21,8 +21,6 @@
 #include <atomic>
 #include <filesystem>
 #include <string>
-#include <thread>
-#include <unistd.h>
 
 template <typename T>
 inline void saveToFile(llvm::StringRef Filepath, T &&Data) {
@@ -41,9 +39,8 @@ template <typename T>
 void saveToFileAtomic(llvm::StringRef Filepath, T &&Data) {
   static std::atomic<uint64_t> TempCounter{0};
   std::string TempPath =
-      Filepath.str() + ".tmp." + std::to_string(getpid()) + "." +
-      std::to_string(std::hash<std::thread::id>{}(std::this_thread::get_id())) +
-      "." + std::to_string(TempCounter.fetch_add(1, std::memory_order_relaxed));
+      Filepath.str() + ".tmp." +
+      std::to_string(TempCounter.fetch_add(1, std::memory_order_relaxed));
 
   std::error_code EC;
   llvm::raw_fd_ostream Out(TempPath, EC);


### PR DESCRIPTION
 This PR fixes an intermittent MPI shared-cache failure caused by concurrent writes using the same temporary filename.

  In `MPIStorageCache`, rank 0 can write cache objects from two paths:

  1. Rank-0 main thread direct store path.
  2. Rank-0 communication thread handling forwarded stores from other ranks.

  `saveToFileAtomic` previously used a fixed temp name (<target>.tmp). With multiple writers targeting the same cache file, one writer could rename/remove that temp file before the other rename, causing a fatal `filesystem::rename(...): No such
  file or directory`. Flux then reported exit-timeout because one rank aborted early.

  This change makes the temp path unique per write via an atomic counter, so concurrent writers do not collide on temp-file names. Final rename to the target path remains atomic.