### PR TITLE
Ensure instrumentation of all kernel function registrations

### DIFF
--- a/src/pass/ProteusPass.cpp
+++ b/src/pass/ProteusPass.cpp
@@ -133,10 +133,10 @@ public:
     instrumentRegisterFatBinary(M);
     instrumentRegisterFatBinaryEnd(M);
     instrumentRegisterVar(M);
+    instrumentRegisterFunction(M);
+
     findJitVariables(M);
     registerLambdaFunctions(M);
-
-    instrumentRegisterFunction(M);
 
     if (hasDeviceLaunchKernelCalls(M)) {
       emitJitLaunchKernelCall(M);


### PR DESCRIPTION
There are cases where a translation defines a kernel but does call it. We still need to instrument the registration.