### PR TITLE
Fix gitlab CI on matrix

### DIFF
--- a/.gitlab/custom-jobs-and-variables.yml
+++ b/.gitlab/custom-jobs-and-variables.yml
@@ -16,7 +16,7 @@ variables:
 # Time in minutes.
 # Arguments for top level allocation
 # Note: can be set to "OFF" to prevent allocation sharing.
-  MATRIX_SHARED_ALLOC: "--exclusive --nodes=1 --time=60 --partition=pdebug"
+  MATRIX_SHARED_ALLOC: "--gpus=1 --nodes=1 --time=60 --partition=pdebug"
 # Arguments for job level allocation
   MATRIX_JOB_ALLOC: "--gpus=1 --nodes=1"
 # Arguments for performance job allocation (dedicated allocation with no overlapping).

--- a/scripts/gitlab/ci-build-test.sh
+++ b/scripts/gitlab/ci-build-test.sh
@@ -12,6 +12,9 @@ if [ "${CI_MACHINE}" == "matrix" ]; then
   ml load cuda/12.2.2
   PYTHON_VERSION=3.12
 
+  # Print GPU information for debugging.
+  echo "CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES} SLURM_STEP_GPUS=${SLURM_STEP_GPUS}"
+
   # Install Clang/LLVM through conda.
   MINICONDA_DIR=miniconda3
   mkdir -p ${MINICONDA_DIR}


### PR DESCRIPTION
- Drop '--exclusive' in outer 'salloc` and add '--gpus=-1' to match 'srun`. Exclusive while subsetting 1 gpu through 'srun' results in the error: 'no CUDA-capable device is detected'