### PR TITLE
[CI] Skip gitlab CI for non-PR branches

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -163,5 +163,8 @@ include:
   - project: 'radiuss/radiuss-shared-ci'
     ref: 'v2025.09.1'
     file: 'utilities/preliminary-ignore-draft-pr.yml'
+  - project: 'radiuss/radiuss-shared-ci'
+    ref: 'v2025.09.1'
+    file: 'utilities/skip-branch-not-a-pr.yml'    
   # pipelines subscribed by the project
   - local: '.gitlab/subscribed-pipelines.yml'


### PR DESCRIPTION
This PR reduces the load on gitlab CI machines.