### PR TITLE
[CI] Use resource_group to limit concurrency for matrix jobs

### DIFF
--- a/.gitlab/jobs/matrix-benchmarks.yml
+++ b/.gitlab/jobs/matrix-benchmarks.yml
@@ -1,6 +1,8 @@
 .base-job:
   extends: .job_on_matrix
   interruptible: true
+  # Serialize actual Matrix runner jobs across all Matrix child pipelines.
+  resource_group: "matrix-ci"
   before_script:
     - echo "=== Start CI Benchmarking ==="
   after_script:

--- a/.gitlab/jobs/matrix-benchmarks.yml
+++ b/.gitlab/jobs/matrix-benchmarks.yml
@@ -1,8 +1,8 @@
 .base-job:
   extends: .job_on_matrix
   interruptible: true
-  # Serialize actual Matrix runner jobs across all Matrix child pipelines.
-  resource_group: "matrix-ci"
+  # Limit actual Matrix runner jobs to two global lanes across child pipelines.
+  resource_group: "matrix-ci-${MATRIX_CI_LANE}"
   before_script:
     - echo "=== Start CI Benchmarking ==="
   after_script:
@@ -11,6 +11,8 @@
 
 proteus-benchmarks-matrix:
   extends: [.base-job]
+  variables:
+    MATRIX_CI_LANE: "1"
   artifacts:
     paths:
       - proteus-benchmarks/results/*.csv

--- a/.gitlab/jobs/matrix-integration.yml
+++ b/.gitlab/jobs/matrix-integration.yml
@@ -1,8 +1,8 @@
 .base-job:
   extends: .job_on_matrix
   interruptible: true
-  # Serialize actual Matrix runner jobs across all Matrix child pipelines.
-  resource_group: "matrix-ci"
+  # Limit actual Matrix runner jobs to two global lanes across child pipelines.
+  resource_group: "matrix-ci-${MATRIX_CI_LANE}"
   before_script:
     - echo "=== Start CI Integration Tests ==="
   after_script:
@@ -13,20 +13,32 @@
 .variants:
   parallel:
     matrix:
-      - PROTEUS_CI_INTEGRATION_TEST:
-        - cmake-shared_libs-shared_proteus
-        - cmake-shared_proteus
-        - cmake-shared_libs-static_proteus
-        - cmake-static_proteus
-        - make-static_proteus
-        - make-shared_proteus
-        - cmake-proteusCore
-        - cmake-shared_lib_and_exe-static_proteus
-        - cmake-proteusFrontend
-        - cmake-clang_plugin-proteusFrontend
-        - cmake-proteusFrontend-gcc
-        - cmake-link_llvm-shared_proteus
-        - mpi-shared-cache
+      - PROTEUS_CI_INTEGRATION_TEST: "cmake-shared_libs-shared_proteus"
+        MATRIX_CI_LANE: "0"
+      - PROTEUS_CI_INTEGRATION_TEST: "cmake-shared_proteus"
+        MATRIX_CI_LANE: "1"
+      - PROTEUS_CI_INTEGRATION_TEST: "cmake-shared_libs-static_proteus"
+        MATRIX_CI_LANE: "0"
+      - PROTEUS_CI_INTEGRATION_TEST: "cmake-static_proteus"
+        MATRIX_CI_LANE: "1"
+      - PROTEUS_CI_INTEGRATION_TEST: "make-static_proteus"
+        MATRIX_CI_LANE: "0"
+      - PROTEUS_CI_INTEGRATION_TEST: "make-shared_proteus"
+        MATRIX_CI_LANE: "1"
+      - PROTEUS_CI_INTEGRATION_TEST: "cmake-proteusCore"
+        MATRIX_CI_LANE: "0"
+      - PROTEUS_CI_INTEGRATION_TEST: "cmake-shared_lib_and_exe-static_proteus"
+        MATRIX_CI_LANE: "1"
+      - PROTEUS_CI_INTEGRATION_TEST: "cmake-proteusFrontend"
+        MATRIX_CI_LANE: "0"
+      - PROTEUS_CI_INTEGRATION_TEST: "cmake-clang_plugin-proteusFrontend"
+        MATRIX_CI_LANE: "1"
+      - PROTEUS_CI_INTEGRATION_TEST: "cmake-proteusFrontend-gcc"
+        MATRIX_CI_LANE: "0"
+      - PROTEUS_CI_INTEGRATION_TEST: "cmake-link_llvm-shared_proteus"
+        MATRIX_CI_LANE: "1"
+      - PROTEUS_CI_INTEGRATION_TEST: "mpi-shared-cache"
+        MATRIX_CI_LANE: "0"
 
 test-integration-matrix:
   extends: [.base-job, .variants]

--- a/.gitlab/jobs/matrix-integration.yml
+++ b/.gitlab/jobs/matrix-integration.yml
@@ -1,6 +1,8 @@
 .base-job:
   extends: .job_on_matrix
   interruptible: true
+  # Serialize actual Matrix runner jobs across all Matrix child pipelines.
+  resource_group: "matrix-ci"
   before_script:
     - echo "=== Start CI Integration Tests ==="
   after_script:

--- a/.gitlab/jobs/matrix-spack.yml
+++ b/.gitlab/jobs/matrix-spack.yml
@@ -1,6 +1,8 @@
 .base-job:
   extends: .job_on_matrix
   interruptible: true
+  # Serialize actual Matrix runner jobs across all Matrix child pipelines.
+  resource_group: "matrix-ci"
   before_script:
     - echo "=== Start CI spack Tests ==="
   after_script:

--- a/.gitlab/jobs/matrix-spack.yml
+++ b/.gitlab/jobs/matrix-spack.yml
@@ -1,8 +1,8 @@
 .base-job:
   extends: .job_on_matrix
   interruptible: true
-  # Serialize actual Matrix runner jobs across all Matrix child pipelines.
-  resource_group: "matrix-ci"
+  # Limit actual Matrix runner jobs to two global lanes across child pipelines.
+  resource_group: "matrix-ci-${MATRIX_CI_LANE}"
   before_script:
     - echo "=== Start CI spack Tests ==="
   after_script:
@@ -15,6 +15,7 @@
     matrix:
       - PROTEUS_CI_CUDA_VERSION: ["12.9"]
         PROTEUS_CI_LLVM_VERSION: ["19.1.3"]
+        MATRIX_CI_LANE: ["0"]
 
 test-spack-matrix:
   extends: [.base-job, .variants]

--- a/.gitlab/jobs/matrix.yml
+++ b/.gitlab/jobs/matrix.yml
@@ -46,8 +46,8 @@ variables:
 .base-job:
   extends: .job_on_matrix
   interruptible: true
-  # Serialize actual Matrix runner jobs across all Matrix child pipelines.
-  resource_group: "matrix-ci"
+  # Limit actual Matrix runner jobs to two global lanes across child pipelines.
+  resource_group: "matrix-ci-${MATRIX_CI_LANE}"
   before_script:
     - echo "=== Start CI Build and Test==="
   after_script:
@@ -59,8 +59,10 @@ variables:
   parallel:
     matrix:
       - PROTEUS_CI_BUILD_SHARED: "on"
+        MATRIX_CI_LANE: "0"
       - PROTEUS_CI_BUILD_SHARED: "off"
         PROTEUS_CODECOV_VARIANT_SELECTED: "1"
+        MATRIX_CI_LANE: "1"
 
 build-and-test-matrix:
   extends: [.base-job, .build-variants]

--- a/.gitlab/jobs/matrix.yml
+++ b/.gitlab/jobs/matrix.yml
@@ -46,6 +46,8 @@ variables:
 .base-job:
   extends: .job_on_matrix
   interruptible: true
+  # Serialize actual Matrix runner jobs across all Matrix child pipelines.
+  resource_group: "matrix-ci"
   before_script:
     - echo "=== Start CI Build and Test==="
   after_script:


### PR DESCRIPTION
- Enable up to 2 active jobs to avoid hogging scarce resources