### PR TITLE
Support PROTEUS_OPT_PIPELINE across LLVM JIT paths

### DIFF
--- a/docs/dev/optimization-pipeline.md
+++ b/docs/dev/optimization-pipeline.md
@@ -1,0 +1,116 @@
+# Optimization Pipeline
+
+This page documents where `PROTEUS_OPT_PIPELINE` applies inside Proteus.
+
+`PROTEUS_OPT_PIPELINE` is a textual LLVM pass pipeline. It is used when Proteus
+owns LLVM IR optimization, or when Proteus can forward the textual pipeline to
+an LLVM API such as LTO. It is not a generic compiler flag for external
+compiler paths such as NVCC, HIPRTC, or Clang shared-library compilation.
+
+## Selection Order
+
+Proteus selects the optimization pipeline from the effective
+`CodeGenerationConfig`:
+
+1. A per-kernel JSON `"Pipeline"` from `PROTEUS_TUNED_KERNELS`, when the code
+   path looks up config by kernel name.
+2. The global `PROTEUS_OPT_PIPELINE` environment variable.
+3. The default pipeline implied by `PROTEUS_OPT_LEVEL`.
+
+Per-kernel JSON `"Pipeline"` currently applies to annotated CUDA/HIP runtime
+JIT paths because they call:
+
+```cpp
+Config::get().getCGConfig(KernelName)
+```
+
+Frontend module compilation currently uses the global config:
+
+```cpp
+Config::get().getCGConfig()
+```
+
+so per-kernel JSON `"Pipeline"` does not naturally apply to DSL, MLIR, or C++
+frontend modules.
+
+## Support Matrix
+
+| Frontend / API path | Target type | Main compile path | Uses `PROTEUS_OPT_PIPELINE`? | Notes |
+| --- | --- | --- | --- | --- |
+| Annotated C/C++ JIT | Host CPU | `JitEngineHost::compileAndLink()` -> `compileOnly()` | Yes | Uses global `CodeGenerationConfig`. Cache key includes codegen config and runtime specialization config. |
+| Annotated CUDA kernel JIT | CUDA device | `JitEngineDeviceCUDA` / `CompilationTask` | Yes | Uses named per-kernel `CodeGenerationConfig`. Explicit LLVM IR optimization before device codegen. |
+| Annotated HIP kernel JIT | HIP, `PROTEUS_CODEGEN=serial` | `CompilationTask` -> `optimizeIR()` -> serial codegen | Yes | Uses named per-kernel `CodeGenerationConfig`. Explicit LLVM IR optimization before serial device codegen. |
+| Annotated HIP kernel JIT | HIP, `PROTEUS_CODEGEN=parallel` | `CompilationTask` -> HIP LTO codegen | Yes | Custom pipeline is forwarded to `llvm::lto::Config::OptPipeline`. |
+| Annotated HIP kernel JIT | HIP, `PROTEUS_CODEGEN=rtc` | `CompilationTask` -> HIPRTC link/compile | No | HIPRTC accepts some compiler options, but does not expose a documented textual LLVM pass pipeline equivalent. |
+| DSL `JitModule`, LLVM backend | Host CPU | DSL -> LLVM IR -> host dispatcher | Yes | Host dispatcher reaches `JitEngineHost::compileOnly()`. Module hash includes codegen config. |
+| DSL `JitModule`, LLVM backend | CUDA device | DSL -> LLVM IR -> CUDA dispatcher | Yes | CUDA dispatcher reaches `JitEngineDeviceCUDA::compileOnly()`. Module hash includes codegen config. |
+| DSL `JitModule`, LLVM backend | HIP device | DSL -> LLVM IR -> HIP dispatcher | Yes | HIP dispatcher reaches `JitEngineDeviceHIP::compileOnly()`. Module hash includes codegen config. |
+| DSL `JitModule`, MLIR backend | Host CPU | MLIR -> LLVM IR -> host dispatcher | Yes | Same dispatcher path as LLVM backend. Module hash includes codegen config. |
+| DSL `JitModule`, MLIR backend | CUDA device | MLIR -> LLVM IR -> CUDA dispatcher | Yes | Same CUDA dispatcher path. Module hash includes codegen config. |
+| DSL `JitModule`, MLIR backend | HIP device | MLIR -> LLVM IR -> HIP dispatcher | Yes | Same HIP dispatcher path. Module hash includes codegen config. |
+| Direct `MLIRJitModule` | Host CPU | MLIR source -> LLVM IR -> host dispatcher | Yes | Uses dispatcher compile path. Module hash includes codegen config. |
+| Direct `MLIRJitModule` | CUDA device | MLIR source -> LLVM IR -> CUDA dispatcher | Yes | Uses dispatcher compile path. Module hash includes codegen config. |
+| Direct `MLIRJitModule` | HIP device | MLIR source -> LLVM IR -> HIP dispatcher | Yes | Uses dispatcher compile path. Module hash includes codegen config. |
+| `CppJitModule`, Clang backend | Host CPU | Clang emits LLVM IR -> host dispatcher | Yes | Clang emits optimized-mode IR with `-O3 -Xclang -disable-llvm-passes`; Proteus runs the configured pipeline. |
+| `CppJitModule`, Clang backend | CUDA device-only | Clang emits device LLVM IR -> CUDA dispatcher | Yes | Proteus optimizes the emitted LLVM IR. Module hash includes codegen config. |
+| `CppJitModule`, Clang backend | HIP device-only | Clang emits device LLVM IR -> HIP dispatcher | Yes | Proteus optimizes the emitted LLVM IR. Module hash includes codegen config. |
+| `CppJitModule`, Clang backend | Host+CUDA | Clang compiles mixed offload translation unit directly to shared library | No | Proteus receives a final `.so`, not host/device LLVM IR. |
+| `CppJitModule`, Clang backend | Host+HIP | Clang compiles mixed offload translation unit directly to shared library | No | Same reason as Host+CUDA. |
+| `CppJitModule`, NVCC backend | CUDA device-only | NVCC emits cubin | No | NVCC owns optimization and codegen. Cache key intentionally does not include Proteus codegen config. |
+| `CppJitModule`, NVCC backend | Host+CUDA | NVCC emits shared library | No | Proteus receives a final binary artifact. Cache key intentionally does not include Proteus codegen config. |
+
+## Cache Key Policy
+
+Cache keys include the configuration that can affect the generated artifact.
+
+Frontend module caches use a codegen-only hash:
+
+```cpp
+hashCodeGenConfig(CGConfig)
+```
+
+This includes:
+
+- `PROTEUS_CODEGEN`
+- `PROTEUS_OPT_LEVEL`
+- `PROTEUS_CODEGEN_OPT_LEVEL`
+- `PROTEUS_OPT_PIPELINE`
+
+Runtime annotated JIT cache keys also include runtime specialization policy:
+
+```cpp
+hashRuntimeSpecializationConfig(CGConfig)
+```
+
+This includes:
+
+- `PROTEUS_SPECIALIZE_ARGS`
+- `PROTEUS_SPECIALIZE_DIMS`
+- `PROTEUS_SPECIALIZE_DIMS_RANGE`
+- `PROTEUS_SPECIALIZE_LAUNCH_BOUNDS`
+
+Those specialization flags are not part of generic frontend module cache keys
+because frontend modules do not use runtime specialization policy in the same
+way annotated runtime JIT paths do.
+
+## Known Exclusions
+
+### HIP RTC
+
+`PROTEUS_CODEGEN=rtc` routes HIP compilation through HIPRTC. The HIPRTC linker
+interface accepts some compiler options, but it does not expose a documented
+LLVM textual pass pipeline interface equivalent to `opt`/PassBuilder or LLVM
+LTO's `OptPipeline`.
+
+### CppJit Host+CUDA / Host+HIP
+
+The Clang backend currently compiles mixed host/device C++ offload source
+directly into a shared library for `HOST_CUDA` and `HOST_HIP`. Proteus receives
+the final `.so`, so it cannot run its LLVM pass pipeline over the host and
+device modules.
+
+### NVCC Backend
+
+The NVCC backend is an external compiler path. Proteus does not own LLVM IR
+optimization there, so `PROTEUS_OPT_PIPELINE` does not apply and is not included
+in NVCC CppJit cache keys.

--- a/docs/dev/proteus-internals.md
+++ b/docs/dev/proteus-internals.md
@@ -1,0 +1,14 @@
+# Proteus Internals
+
+This section documents implementation-level behavior that cuts across multiple
+frontends, target models, and runtime paths.
+
+The user guide describes how to use Proteus APIs. These internals notes explain
+how the runtime routes work, which components own compilation decisions, and
+where configuration options take effect.
+
+## Topics
+
+- [Optimization Pipeline](optimization-pipeline.md): how
+  `PROTEUS_OPT_PIPELINE` is selected, which compile paths use it, and how it
+  participates in cache keys.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,9 @@ nav:
       - Resources : user/resources.md
   - Developer's manual:
     - Concepts: dev/concepts.md
+    - Proteus Internals:
+      - Overview: dev/proteus-internals.md
+      - Optimization Pipeline: dev/optimization-pipeline.md
     - Creating a PR: dev/pr.md
     - API Reference: dev/api.md
 repo_url: https://github.com/Olympus-HPC/proteus

--- a/src/include/proteus/impl/CompilationTask.h
+++ b/src/include/proteus/impl/CompilationTask.h
@@ -37,9 +37,7 @@ private:
   bool SpecializeDims;
   bool SpecializeDimsRange;
   bool SpecializeLaunchBounds;
-  char OptLevel;
-  unsigned CodegenOptLevel;
-  std::optional<std::string> PassPipeline;
+  OptimizationPipelineConfig OptConfig;
 
   std::unique_ptr<Module> cloneKernelModule(LLVMContext &Ctx) {
     TIMESCOPE(CompilationTask, cloneKernelModule);
@@ -53,8 +51,6 @@ private:
 
   void invokeOptimizeIR(Module &M) {
     TIMESCOPE(CompilationTask, invokeOptimizeIR);
-    OptimizationPipelineConfig OptConfig(PassPipeline, OptLevel,
-                                         CodegenOptLevel);
 #if PROTEUS_ENABLE_CUDA
     // For CUDA we always run the optimization pipeline.
     optimizeIR(M, DeviceArch, OptConfig);
@@ -93,9 +89,7 @@ public:
         SpecializeDims(CGConfig.specializeDims()),
         SpecializeDimsRange(CGConfig.specializeDimsRange()),
         SpecializeLaunchBounds(CGConfig.specializeLaunchBounds()),
-        OptLevel(CGConfig.optLevel()),
-        CodegenOptLevel(CGConfig.codeGenOptLevel()),
-        PassPipeline(CGConfig.optPipeline()) {
+        OptConfig(CGConfig) {
     if (Config::get().traceSpecializations()) {
       llvm::SmallString<128> S;
       llvm::raw_svector_ostream OS(S);
@@ -179,7 +173,7 @@ public:
         proteus::codegenObject(*M, DeviceArch, GlobalLinkedBinaries, CGOption);
 #elif PROTEUS_ENABLE_HIP
     auto ObjBuf = proteus::codegenObject(*M, DeviceArch, GlobalLinkedBinaries,
-                                         CGOption, PassPipeline);
+                                         CGOption, OptConfig);
 #endif
 
     if (!RelinkGlobalsByCopy)

--- a/src/include/proteus/impl/CompilationTask.h
+++ b/src/include/proteus/impl/CompilationTask.h
@@ -53,23 +53,18 @@ private:
 
   void invokeOptimizeIR(Module &M) {
     TIMESCOPE(CompilationTask, invokeOptimizeIR);
+    OptimizationPipelineConfig OptConfig(PassPipeline, OptLevel,
+                                         CodegenOptLevel);
 #if PROTEUS_ENABLE_CUDA
     // For CUDA we always run the optimization pipeline.
-    if (!PassPipeline)
-      optimizeIR(M, DeviceArch, OptLevel, CodegenOptLevel);
-    else
-      optimizeIR(M, DeviceArch, PassPipeline.value(), CodegenOptLevel);
+    optimizeIR(M, DeviceArch, OptConfig);
 #elif PROTEUS_ENABLE_HIP
-    // For HIP we run the optimization pipeline only for Serial codegen. HIP RTC
-    // and Parallel codegen, which uses LTO, invoke optimization internally.
+    // For HIP we run the optimization pipeline here only for Serial codegen.
+    // Parallel codegen forwards custom pipelines to LTO; HIP RTC invokes
+    // optimization internally.
     // TODO: Move optimizeIR inside the codegen routines?
-    if (CGOption == CodegenOption::Serial) {
-      if (!PassPipeline) {
-        optimizeIR(M, DeviceArch, OptLevel, CodegenOptLevel);
-      } else {
-        optimizeIR(M, DeviceArch, PassPipeline.value(), CodegenOptLevel);
-      }
-    }
+    if (CGOption == CodegenOption::Serial)
+      optimizeIR(M, DeviceArch, OptConfig);
 #else
 #error "JitEngineDevice requires PROTEUS_ENABLE_CUDA or PROTEUS_ENABLE_HIP"
 #endif
@@ -179,8 +174,13 @@ public:
                  *M);
     }
 
+#if PROTEUS_ENABLE_CUDA
     auto ObjBuf =
         proteus::codegenObject(*M, DeviceArch, GlobalLinkedBinaries, CGOption);
+#elif PROTEUS_ENABLE_HIP
+    auto ObjBuf = proteus::codegenObject(*M, DeviceArch, GlobalLinkedBinaries,
+                                         CGOption, PassPipeline);
+#endif
 
     if (!RelinkGlobalsByCopy)
       proteus::relinkGlobalsObject(ObjBuf->getMemBufferRef(),

--- a/src/include/proteus/impl/CoreLLVM.h
+++ b/src/include/proteus/impl/CoreLLVM.h
@@ -44,6 +44,10 @@ static_assert(__cplusplus >= 201703L,
 #include <llvm/Transforms/IPO/StripSymbols.h>
 #include <llvm/Transforms/Utils/ModuleUtils.h>
 
+#include <optional>
+#include <string>
+#include <utility>
+
 namespace proteus {
 using namespace llvm;
 
@@ -180,35 +184,53 @@ struct InitLLVMTargets {
   }
 };
 
-inline void optimizeIR(Module &M, StringRef Arch, char OptLevel,
-                       unsigned CodegenOptLevel) {
-  TIMESCOPE("proteus::optimizeIR");
-  Timer T(Config::get().ProteusEnableTimers);
-  detail::runOptimizationPassPipeline(M, Arch, OptLevel, CodegenOptLevel);
-  PROTEUS_TIMER_OUTPUT(Logger::outs("proteus")
-                       << "optimizeIR optlevel " << OptLevel << " codegenopt "
-                       << CodegenOptLevel << " " << T.elapsed() << " ms\n");
-}
+struct OptimizationPipelineConfig {
+  std::optional<std::string> PassPipeline;
+  char OptLevel;
+  unsigned CodegenOptLevel;
+
+  explicit OptimizationPipelineConfig(const CodeGenerationConfig &CGConfig)
+      : OptLevel(CGConfig.optLevel()),
+        CodegenOptLevel(CGConfig.codeGenOptLevel()) {
+    if (auto Pipeline = CGConfig.optPipeline())
+      PassPipeline = Pipeline.value();
+  }
+
+  OptimizationPipelineConfig(std::optional<std::string> PassPipeline,
+                             char OptLevel, unsigned CodegenOptLevel)
+      : PassPipeline(std::move(PassPipeline)), OptLevel(OptLevel),
+        CodegenOptLevel(CodegenOptLevel) {}
+};
 
 inline void optimizeIR(Module &M, StringRef Arch,
-                       const std::string &PassPipeline,
-                       unsigned CodegenOptLevel) {
+                       const OptimizationPipelineConfig &OptConfig) {
   TIMESCOPE("proteus::optimizeIR");
   Timer T(Config::get().ProteusEnableTimers);
-  auto TraceOut = [](const std::string &PassPipeline) {
-    SmallString<128> S;
-    raw_svector_ostream OS(S);
-    OS << "[CustomPipeline] " << PassPipeline << "\n";
-    return S;
-  };
 
-  if (Config::get().traceSpecializations())
-    Logger::trace(TraceOut(PassPipeline));
+  if (OptConfig.PassPipeline) {
+    auto TraceOut = [](const std::string &PassPipeline) {
+      SmallString<128> S;
+      raw_svector_ostream OS(S);
+      OS << "[CustomPipeline] " << PassPipeline << "\n";
+      return S;
+    };
 
-  detail::runOptimizationPassPipeline(M, Arch, PassPipeline, CodegenOptLevel);
+    if (Config::get().traceSpecializations())
+      Logger::trace(TraceOut(OptConfig.PassPipeline.value()));
+
+    detail::runOptimizationPassPipeline(M, Arch, OptConfig.PassPipeline.value(),
+                                        OptConfig.CodegenOptLevel);
+  } else {
+    detail::runOptimizationPassPipeline(M, Arch, OptConfig.OptLevel,
+                                        OptConfig.CodegenOptLevel);
+  }
+
   PROTEUS_TIMER_OUTPUT(Logger::outs("proteus")
-                       << "optimizeIR optlevel " << PassPipeline
-                       << " codegenopt " << CodegenOptLevel << " "
+                       << "optimizeIR optlevel "
+                       << (OptConfig.PassPipeline
+                               ? StringRef(OptConfig.PassPipeline.value())
+                               : StringRef(&OptConfig.OptLevel, 1))
+                       << " codegenopt " << OptConfig.CodegenOptLevel << " "
                        << T.elapsed() << " ms\n");
 }
 

--- a/src/include/proteus/impl/CoreLLVMHIP.h
+++ b/src/include/proteus/impl/CoreLLVMHIP.h
@@ -189,9 +189,9 @@ codegenSerial(Module &M, StringRef DeviceArch,
 }
 
 inline SmallVector<std::unique_ptr<sys::fs::TempFile>>
-codegenParallel(Module &M, StringRef DeviceArch, unsigned int OptLevel = 3,
-                int CodegenOptLevel = 3,
-                std::optional<std::string> OptPipeline = std::nullopt) {
+codegenParallel(Module &M, StringRef DeviceArch,
+                const OptimizationPipelineConfig &OptConfig =
+                    OptimizationPipelineConfig(std::nullopt, '3', 3)) {
   TIMESCOPE("proteus::codegenParallel");
   // Use regular LTO with parallelism enabled to parallelize codegen.
   std::atomic<bool> LTOError = false;
@@ -220,8 +220,8 @@ codegenParallel(Module &M, StringRef DeviceArch, unsigned int OptLevel = 3,
   };
 
   // Create TargetMachine and extract options/features.
-  auto ExpectedTM =
-      proteus::detail::createTargetMachine(M, DeviceArch, CodegenOptLevel);
+  auto ExpectedTM = proteus::detail::createTargetMachine(
+      M, DeviceArch, OptConfig.CodegenOptLevel);
   if (!ExpectedTM)
     reportFatalError(toString(ExpectedTM.takeError()));
   std::unique_ptr<TargetMachine> TM = std::move(*ExpectedTM);
@@ -248,12 +248,12 @@ codegenParallel(Module &M, StringRef DeviceArch, unsigned int OptLevel = 3,
   Conf.DebugPassManager = false;
   Conf.VerifyEach = false;
   Conf.DiagHandler = DiagnosticHandler;
-  Conf.OptLevel = OptLevel;
+  Conf.OptLevel = OptConfig.OptLevel;
   // Parallel codegen lets LTO own optimization, so custom textual pipelines
   // must be forwarded to the LTO configuration instead of run beforehand.
-  if (OptPipeline)
-    Conf.OptPipeline = OptPipeline.value();
-  Conf.CGOptLevel = static_cast<CodeGenOptLevel>(CodegenOptLevel);
+  if (OptConfig.PassPipeline)
+    Conf.OptPipeline = OptConfig.PassPipeline.value();
+  Conf.CGOptLevel = static_cast<CodeGenOptLevel>(OptConfig.CodegenOptLevel);
 
   unsigned ParallelCodeGenParallelismLevel =
       std::max(1u, std::thread::hardware_concurrency());
@@ -451,7 +451,8 @@ inline std::unique_ptr<MemoryBuffer>
 codegenObject(Module &M, StringRef DeviceArch,
               [[maybe_unused]] SmallPtrSetImpl<void *> &GlobalLinkedBinaries,
               CodegenOption CGOption = CodegenOption::RTC,
-              std::optional<std::string> OptPipeline = std::nullopt) {
+              const OptimizationPipelineConfig &OptConfig =
+                  OptimizationPipelineConfig(std::nullopt, '3', 3)) {
   TIMESCOPE("proteus::codegenObjectHIP");
   assert(GlobalLinkedBinaries.empty() &&
          "Expected empty linked binaries for HIP");
@@ -469,8 +470,7 @@ codegenObject(Module &M, StringRef DeviceArch,
     ObjectFiles = detail::codegenSerial(M, DeviceArch);
     break;
   case CodegenOption::Parallel:
-    ObjectFiles = detail::codegenParallel(M, DeviceArch, /*OptLevel=*/3,
-                                          /*CodegenOptLevel=*/3, OptPipeline);
+    ObjectFiles = detail::codegenParallel(M, DeviceArch, OptConfig);
     break;
 #endif
   default:

--- a/src/include/proteus/impl/CoreLLVMHIP.h
+++ b/src/include/proteus/impl/CoreLLVMHIP.h
@@ -27,6 +27,8 @@
 #include <llvm/Support/WithColor.h>
 #include <llvm/Target/TargetMachine.h>
 
+#include <optional>
+
 #if LLVM_VERSION_MAJOR >= 18
 #include <lld/Common/Driver.h>
 LLD_HAS_DRIVER(elf)
@@ -188,7 +190,8 @@ codegenSerial(Module &M, StringRef DeviceArch,
 
 inline SmallVector<std::unique_ptr<sys::fs::TempFile>>
 codegenParallel(Module &M, StringRef DeviceArch, unsigned int OptLevel = 3,
-                int CodegenOptLevel = 3) {
+                int CodegenOptLevel = 3,
+                std::optional<std::string> OptPipeline = std::nullopt) {
   TIMESCOPE("proteus::codegenParallel");
   // Use regular LTO with parallelism enabled to parallelize codegen.
   std::atomic<bool> LTOError = false;
@@ -246,6 +249,10 @@ codegenParallel(Module &M, StringRef DeviceArch, unsigned int OptLevel = 3,
   Conf.VerifyEach = false;
   Conf.DiagHandler = DiagnosticHandler;
   Conf.OptLevel = OptLevel;
+  // Parallel codegen lets LTO own optimization, so custom textual pipelines
+  // must be forwarded to the LTO configuration instead of run beforehand.
+  if (OptPipeline)
+    Conf.OptPipeline = OptPipeline.value();
   Conf.CGOptLevel = static_cast<CodeGenOptLevel>(CodegenOptLevel);
 
   unsigned ParallelCodeGenParallelismLevel =
@@ -443,7 +450,8 @@ inline void setLaunchBoundsForKernel(Function &F, int MaxNumWorkGroups,
 inline std::unique_ptr<MemoryBuffer>
 codegenObject(Module &M, StringRef DeviceArch,
               [[maybe_unused]] SmallPtrSetImpl<void *> &GlobalLinkedBinaries,
-              CodegenOption CGOption = CodegenOption::RTC) {
+              CodegenOption CGOption = CodegenOption::RTC,
+              std::optional<std::string> OptPipeline = std::nullopt) {
   TIMESCOPE("proteus::codegenObjectHIP");
   assert(GlobalLinkedBinaries.empty() &&
          "Expected empty linked binaries for HIP");
@@ -461,7 +469,8 @@ codegenObject(Module &M, StringRef DeviceArch,
     ObjectFiles = detail::codegenSerial(M, DeviceArch);
     break;
   case CodegenOption::Parallel:
-    ObjectFiles = detail::codegenParallel(M, DeviceArch);
+    ObjectFiles = detail::codegenParallel(M, DeviceArch, /*OptLevel=*/3,
+                                          /*CodegenOptLevel=*/3, OptPipeline);
     break;
 #endif
   default:

--- a/src/include/proteus/impl/Hashing.h
+++ b/src/include/proteus/impl/Hashing.h
@@ -3,6 +3,7 @@
 
 #include "proteus/CompilerInterfaceTypes.h"
 #include "proteus/TimeTracing.h"
+#include "proteus/impl/Config.h"
 #include "proteus/impl/RuntimeConstantTypeHelpers.h"
 
 #include <llvm/ADT/ArrayRef.h>
@@ -136,6 +137,31 @@ inline HashT hashValue(ArrayRef<RuntimeConstant> Arr) {
 
 inline HashT hashCombine(HashT A, HashT B) {
   return stable_hash_combine(A.getValue(), B.getValue());
+}
+
+inline HashT hashCodeGenConfig(const CodeGenerationConfig &CGConfig) {
+  HashT H = hashValue(static_cast<int>(CGConfig.codeGenOption()));
+  H = hashCombine(H, hashValue(CGConfig.optLevel()));
+  H = hashCombine(H, hashValue(CGConfig.codeGenOptLevel()));
+  if (auto Pipeline = CGConfig.optPipeline())
+    H = hashCombine(H, hashValue(Pipeline.value()));
+  return H;
+}
+
+inline HashT
+hashRuntimeSpecializationConfig(const CodeGenerationConfig &CGConfig) {
+  HashT H = hashValue(CGConfig.specializeArgs());
+  H = hashCombine(H, hashValue(CGConfig.specializeDims()));
+  H = hashCombine(H, hashValue(CGConfig.specializeDimsRange()));
+  H = hashCombine(H, hashValue(CGConfig.specializeLaunchBounds()));
+  return H;
+}
+
+// The generic CodeGenerationConfig hash is codegen-only so frontend module
+// caches do not depend on runtime specialization policy. Runtime JIT cache keys
+// add hashRuntimeSpecializationConfig explicitly where those flags apply.
+inline HashT hashValue(const CodeGenerationConfig &CGConfig) {
+  return hashCodeGenConfig(CGConfig);
 }
 
 template <typename FirstT, typename... RestTs>

--- a/src/include/proteus/impl/JitEngineDevice.h
+++ b/src/include/proteus/impl/JitEngineDevice.h
@@ -578,13 +578,15 @@ JitEngineDevice<ImplT>::compileAndRun(
 
   SmallVector<RuntimeConstant> LambdaJitValuesVec;
   getLambdaJitValues(KernelInfo, LambdaJitValuesVec);
-  // Determine the hash based on dimension specialization.  If we do not
-  // specialize IR based on grid dimensions, avoid hashing on those to
-  // eliminate repeated compilation overhead.
-  HashT HashValue = hash(getStaticHash(KernelInfo), RCVec, LambdaJitValuesVec,
-                         BlockDim.x, BlockDim.y, BlockDim.z);
-  if (Config::get().getCGConfig().specializeDims() ||
-      Config::get().getCGConfig().specializeDimsRange())
+  const auto &CGConfig = Config::get().getCGConfig(KernelInfo.getName());
+  // Include codegen and runtime specialization policy in the cache key. If we
+  // do not specialize IR based on grid dimensions, avoid hashing on grid dims
+  // to eliminate repeated compilation overhead.
+  HashT HashValue =
+      hash(getStaticHash(KernelInfo), RCVec, LambdaJitValuesVec, BlockDim.x,
+           BlockDim.y, BlockDim.z, hashCodeGenConfig(CGConfig),
+           hashRuntimeSpecializationConfig(CGConfig));
+  if (CGConfig.specializeDims() || CGConfig.specializeDimsRange())
     HashValue = hash(HashValue, GridDim.x, GridDim.y, GridDim.z);
 
   typename DeviceTraits<ImplT>::KernelFunction_t KernelFunc =
@@ -633,7 +635,7 @@ JitEngineDevice<ImplT>::compileAndRun(
           KernelBitcode, HashValue, KernelInfo.getName(), Suffix, BlockDim,
           GridDim, RCVec, KernelInfo.getLambdaCalleeInfo(),
           BinInfo.getVarNameToGlobalInfo(), GlobalLinkedBinaries, DeviceArch,
-          /*CodeGenConfig */ Config::get().getCGConfig(KernelInfo.getName()),
+          /*CodeGenConfig */ CGConfig,
           /*DumpIR*/ Config::get().ProteusDumpLLVMIR,
           /*RelinkGlobalsByCopy*/ Config::get().ProteusRelinkGlobalsByCopy});
     }
@@ -653,7 +655,7 @@ JitEngineDevice<ImplT>::compileAndRun(
         KernelBitcode, HashValue, KernelInfo.getName(), Suffix, BlockDim,
         GridDim, RCVec, KernelInfo.getLambdaCalleeInfo(),
         BinInfo.getVarNameToGlobalInfo(), GlobalLinkedBinaries, DeviceArch,
-        /*CodeGenConfig */ Config::get().getCGConfig(KernelInfo.getName()),
+        /*CodeGenConfig */ CGConfig,
         /*DumpIR*/ Config::get().ProteusDumpLLVMIR,
         /*RelinkGlobalsByCopy*/ Config::get().ProteusRelinkGlobalsByCopy});
   }

--- a/src/runtime/Frontend/CppJitCompiler.cpp
+++ b/src/runtime/Frontend/CppJitCompiler.cpp
@@ -55,6 +55,8 @@ HashT computeCppJitModuleHash(TargetModelType TM, CppJitCompilerBackend Backend,
                               const std::string &Code,
                               const std::vector<std::string> &ExtraArgs) {
   HashT H = hash(static_cast<int>(TM), static_cast<int>(Backend), Code);
+  if (Backend == CppJitCompilerBackend::Clang)
+    H = hashCombine(H, hashCodeGenConfig(Config::get().getCGConfig()));
   for (const auto &Arg : ExtraArgs)
     H = hashCombine(H, hash(Arg));
   return H;

--- a/src/runtime/Frontend/CppJitCompilerClang.cpp
+++ b/src/runtime/Frontend/CppJitCompilerClang.cpp
@@ -125,12 +125,18 @@ private:
     std::string SourceName = Request.ModuleHash.toString() + ".cpp";
 
     std::vector<std::string> ArgStorage;
+    // Keep Clang in optimized frontend/codegen mode so it emits optimized-mode
+    // IR features such as fmuladd, but skip Clang's LLVM pass pipeline. Proteus
+    // runs its configured middle-end pipeline when the dispatcher compiles the
+    // returned LLVM IR.
     if (Request.TargetModel == TargetModelType::HOST) {
       ArgStorage = {PROTEUS_CLANGXX_BIN,
                     "-emit-llvm",
                     "-S",
                     "-std=c++17",
                     CppJitCompiler::FrontendOptLevelFlag,
+                    "-Xclang",
+                    "-disable-llvm-passes",
                     "-x",
                     "c++",
                     "-fPIC",
@@ -143,6 +149,8 @@ private:
           "-S",
           "-std=c++17",
           CppJitCompiler::FrontendOptLevelFlag,
+          "-Xclang",
+          "-disable-llvm-passes",
           "-x",
           (Request.TargetModel == TargetModelType::HIP ? "hip" : "cuda"),
           "--offload-device-only",

--- a/src/runtime/Frontend/CppJitModule.cpp
+++ b/src/runtime/Frontend/CppJitModule.cpp
@@ -68,8 +68,7 @@ void CppJitModule::compile() {
     break;
   case CppJitArtifact::Kind::LLVMIR: {
     auto ObjectModule = Dispatch.compile(std::move(Artifact.Ctx),
-                                         std::move(Artifact.Mod), *ModuleHash,
-                                         /*DisableIROpt=*/true);
+                                         std::move(Artifact.Mod), *ModuleHash);
     Library = std::make_unique<CompiledLibrary>(std::move(ObjectModule));
     break;
   }

--- a/src/runtime/Frontend/JitFrontend.cpp
+++ b/src/runtime/Frontend/JitFrontend.cpp
@@ -75,11 +75,11 @@ void JitModule::compile(bool Verify) {
   raw_svector_ostream OS(Buffer);
   WriteBitcodeToFile(*Mod, OS);
 
-  // Create a unique module hash based on the bitcode and append to all
-  // function names to make them unique.
+  // Create a unique module hash based on the bitcode and codegen config, then
+  // append it to all function names to make them unique.
   // TODO: Is this necessary?
-  ModuleHash =
-      std::make_unique<HashT>(hash(StringRef{Buffer.data(), Buffer.size()}));
+  ModuleHash = std::make_unique<HashT>(hash(
+      StringRef{Buffer.data(), Buffer.size()}, Config::get().getCGConfig()));
   for (auto &JitF : Functions) {
     const std::string OldName = JitF->getName();
     const std::string NewName = OldName + ModuleHash->toMangledSuffix();

--- a/src/runtime/Frontend/MLIRJitModule.cpp
+++ b/src/runtime/Frontend/MLIRJitModule.cpp
@@ -20,10 +20,10 @@ MLIRJitModule::MLIRJitModule(TargetModelType TargetModel,
                              const std::string &Code)
     : TargetModel(TargetModel), Code(Code),
       Dispatch(Dispatcher::getDispatcher(TargetModel)) {
-  // Hash the MLIR source and include the target model because the same MLIR
-  // lowers to different artifacts for host, CUDA, HIP.
-  ModuleHash =
-      std::make_unique<HashT>(hash(static_cast<int>(TargetModel), Code));
+  // Hash the MLIR source, target model, and codegen config because each can
+  // lower/compile to a different artifact.
+  ModuleHash = std::make_unique<HashT>(
+      hash(static_cast<int>(TargetModel), Code, Config::get().getCGConfig()));
 }
 
 MLIRJitModule::MLIRJitModule(const std::string &Target, const std::string &Code)

--- a/src/runtime/JitEngineDeviceCUDA.cpp
+++ b/src/runtime/JitEngineDeviceCUDA.cpp
@@ -170,8 +170,7 @@ JitEngineDeviceCUDA::compileOnly(Module &M, bool DisableIROpt) {
   TIMESCOPE(JitEngineDeviceCUDA, compileOnly);
   if (!DisableIROpt) {
     const auto &CGConfig = Config::get().getCGConfig();
-    proteus::optimizeIR(M, DeviceArch, CGConfig.optLevel(),
-                        CGConfig.codeGenOptLevel());
+    proteus::optimizeIR(M, DeviceArch, OptimizationPipelineConfig(CGConfig));
   } else {
     if (Config::get().traceSpecializations())
       Logger::trace("[SkipOpt] Skipping JitEngine IR optimization\n");

--- a/src/runtime/JitEngineDeviceHIP.cpp
+++ b/src/runtime/JitEngineDeviceHIP.cpp
@@ -384,6 +384,7 @@ JitEngineDeviceHIP::compileOnly(Module &M, bool DisableIROpt) {
   }
   const auto &CGConfig = Config::get().getCGConfig();
   auto DeviceObject = proteus::codegenObject(
-      M, DeviceArch, GlobalLinkedBinaries, CGConfig.codeGenOption());
+      M, DeviceArch, GlobalLinkedBinaries, CGConfig.codeGenOption(),
+      OptimizationPipelineConfig(CGConfig));
   return DeviceObject;
 }

--- a/src/runtime/JitEngineDeviceHIP.cpp
+++ b/src/runtime/JitEngineDeviceHIP.cpp
@@ -377,8 +377,7 @@ JitEngineDeviceHIP::compileOnly(Module &M, bool DisableIROpt) {
   TIMESCOPE(JitEngineDeviceHIP, compileOnly);
   if (!DisableIROpt) {
     const auto &CGConfig = Config::get().getCGConfig();
-    proteus::optimizeIR(M, DeviceArch, CGConfig.optLevel(),
-                        CGConfig.codeGenOptLevel());
+    proteus::optimizeIR(M, DeviceArch, OptimizationPipelineConfig(CGConfig));
   } else {
     if (Config::get().traceSpecializations())
       Logger::trace("[SkipOpt] Skipping JitEngine IR optimization\n");

--- a/src/runtime/JitEngineHost.cpp
+++ b/src/runtime/JitEngineHost.cpp
@@ -219,7 +219,10 @@ JitEngineHost::compileAndLink(StringRef FnName, char *IR, int IRSize,
   SmallVector<RuntimeConstant> LambdaJitValuesVec;
   getLambdaJitValues(FnName, LambdaJitValuesVec);
 
-  HashT HashValue = hash(StrIR, FnName, RCVec, LambdaJitValuesVec);
+  const auto &CGConfig = Config::get().getCGConfig();
+  HashT HashValue = hash(StrIR, FnName, RCVec, LambdaJitValuesVec,
+                         hashCodeGenConfig(CGConfig),
+                         hashRuntimeSpecializationConfig(CGConfig));
   if (Config::get().ProteusDebugOutput) {
     Logger::logs("proteus")
         << "Hashing: " << " FnName " << FnName << " RCVec [ ";
@@ -297,12 +300,7 @@ std::unique_ptr<MemoryBuffer> JitEngineHost::compileOnly(Module &M,
   // Add optimization passes.
   if (!DisableIROpt) {
     const auto &CGConfig = Config::get().getCGConfig();
-    if (CGConfig.optPipeline()) {
-      optimizeIR(M, sys::getHostCPUName(), CGConfig.optPipeline().value(),
-                 CGConfig.codeGenOptLevel());
-    } else
-      optimizeIR(M, sys::getHostCPUName(), CGConfig.optLevel(),
-                 CGConfig.codeGenOptLevel());
+    optimizeIR(M, sys::getHostCPUName(), OptimizationPipelineConfig(CGConfig));
   } else {
     if (Config::get().traceSpecializations())
       Logger::trace("[SkipOpt] Skipping JitEngine IR optimization\n");

--- a/tests/frontend/gpu/cpp_adam.cpp
+++ b/tests/frontend/gpu/cpp_adam.cpp
@@ -187,7 +187,6 @@ int main(int argc, char *argv[]) {
 // CHECK-NEXT: init p[9] = 0.559506
 // CHECK-NEXT: Creating JIT module
 // CHECK: Compiling JIT module
-// CHECK-FIRST: [SkipOpt] Skipping JitEngine IR optimization
 // CHECK-NEXT: Average kernel execution time {{.*}} (ms)
 // Low-order digits vary slightly across CUDA/HIP toolchains and LLVM versions.
 // CHECK-NEXT: p[0] = -0.5729{{[0-9]*}}

--- a/tests/integration/cuda/cmake-proteusCore/jit.cpp
+++ b/tests/integration/cuda/cmake-proteusCore/jit.cpp
@@ -1,5 +1,6 @@
 #include <cstdlib>
 #include <iostream>
+#include <optional>
 #include <string>
 
 #include <proteus/Error.h>
@@ -45,7 +46,9 @@ int main(int argc, char **argv) {
   auto Mod = std::move(ModuleOrErr.get());
   proteus::pruneIR(*Mod);
   proteus::internalize(*Mod, KernelSym);
-  proteus::optimizeIR(*Mod, DeviceArch, '1', 1);
+  proteus::optimizeIR(
+      *Mod, DeviceArch,
+      proteus::OptimizationPipelineConfig(std::nullopt, '1', 1));
   auto DeviceObject =
       proteus::codegenObject(*Mod, DeviceArch, GlobalLinkedBinaries);
   if (!DeviceObject)

--- a/tests/integration/hip/cmake-proteusCore/jit.cpp
+++ b/tests/integration/hip/cmake-proteusCore/jit.cpp
@@ -1,5 +1,6 @@
 #include <cstdlib>
 #include <iostream>
+#include <optional>
 #include <string>
 
 #include <proteus/Error.h>
@@ -47,7 +48,9 @@ int main(int argc, char **argv) {
   auto Mod = std::move(ModuleOrErr.get());
   proteus::pruneIR(*Mod);
   proteus::internalize(*Mod, KernelSym);
-  proteus::optimizeIR(*Mod, DeviceArch, '1', 1);
+  proteus::optimizeIR(
+      *Mod, DeviceArch,
+      proteus::OptimizationPipelineConfig(std::nullopt, '1', 1));
   auto DeviceObject =
       proteus::codegenObject(*Mod, DeviceArch, GlobalLinkedBinaries);
   if (!DeviceObject)


### PR DESCRIPTION
Make Proteus-owned LLVM optimization paths consistently use the configured optimization pipeline. This includes frontend compileOnly paths, CppJit Clang LLVM IR compilation, and HIP parallel LTO codegen.

Also update cache keys so pipeline-affecting codegen configuration invalidates the right artifacts, while keeping runtime specialization policy separate from frontend module hashes. Document the resulting optimization pipeline behavior and support matrix in the developer internals docs.

Closes #379 
Closes #274 
