### PR TITLE
Add LLVM IR JIT module and frontend tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Several frontends are available, depending on how you want to describe JIT code:
 | --- | --- | --- | --- | --- |
 | **Code annotations** | Existing C/C++/CUDA/HIP code | Incremental adoption in existing applications | Values, arrays, objects, and launch configuration | Yes |
 | **C++ frontend API** | C++ source strings | Runtime-generated C++ and templates | Values, arrays, objects, and launch configuration | No |
+| **LLVM IR frontend API** | LLVM IR text or bitcode | Reusing externally generated LLVM IR with Proteus caching and dispatch | Encoded in the provided LLVM IR | No |
 | **MLIR frontend API** | MLIR source strings | Direct access to MLIR lowering | Encoded in the provided MLIR source | No |
 | **Embedded DSL API** | Programmatic builders | Runtime code generation with high-level constructs | Values, arrays, and launch configuration | No |
 
@@ -36,6 +37,7 @@ support depending on how Proteus was configured:
 | --- | --- | --- | --- | --- |
 | **Code annotations** | Yes | Yes | Yes | Requires compiling with Clang and uses the Proteus LLVM pass |
 | **C++ frontend API** | Yes | Yes | Yes | Uses Clang by default; CUDA paths can use NVCC |
+| **LLVM IR frontend API** | Yes | Yes | Yes | Accepts LLVM IR text or bitcode and compiles it directly through LLVM |
 | **MLIR frontend API** | Yes | Yes | Yes | Requires `PROTEUS_ENABLE_MLIR=ON` |
 | **Embedded DSL API** | Yes | Yes | Yes | Uses the LLVM backend by default; MLIR backend requires `PROTEUS_ENABLE_MLIR=ON` |
 
@@ -49,7 +51,7 @@ Proteus consists of an LLVM pass and a runtime library that implements JIT
 compilation and optimization using LLVM as a library.
 
 * The **code annotation** interface requires compiling your application with Clang so the Proteus LLVM pass can parse annotations.
-* The **DSL**, **C++ frontend**, and **MLIR frontend** APIs don’t depend on which AOT compiler you use.
+* The **DSL**, **C++ frontend**, **LLVM IR frontend**, and **MLIR frontend** APIs don’t depend on which AOT compiler you use.
 
 In all cases, you link your application against the Proteus runtime library.
 Details are provided [later](#integrating-with-your-build-system).
@@ -62,10 +64,11 @@ The first Python wheel target is CPU-only and ships the Python bindings,
 `libproteus`, and the LLVM/Clang runtime libraries needed by Proteus itself.
 CUDA, HIP/ROCm, MLIR, and MPI are not included in this first wheel.
 
-The host C++ JIT frontend remains available, but it still requires a compatible
-host `clang++` installation at runtime. Proteus resolves `clang++` from
-`PROTEUS_CLANGXX_BIN`, then from an LLVM-adjacent toolchain hint, then from
-`PATH`.
+The host LLVM IR frontend is available in the wheel as-is.
+The host C++ JIT frontend also remains available, but it still requires a
+compatible host `clang++` installation at runtime.
+Proteus resolves `clang++` from `PROTEUS_CLANGXX_BIN`, then from an
+LLVM-adjacent toolchain hint, then from `PATH`.
 
 ### Spack
 We provide a packaging recipe for Spack in the subdirectory `packaging/spack`.
@@ -138,7 +141,7 @@ find_package(proteus CONFIG REQUIRED)
 add_proteus(<target>)
 ```
 
-If you only need the DSL, C++ frontend, or MLIR frontend APIs, you can link directly against
+If you only need the DSL, C++ frontend, LLVM IR frontend, or MLIR frontend APIs, you can link directly against
 `proteusFrontend`.
 In this case, you don’t need to compile your target with Clang:
 
@@ -177,6 +180,7 @@ work:
 | --- | --- |
 | Code annotations | [Code Annotations](https://olympus-hpc.github.io/proteus/user/annotations/) |
 | C++ frontend API | [C++ Frontend API](https://olympus-hpc.github.io/proteus/user/cpp-frontend/) |
+| LLVM IR frontend API | [LLVM IR Frontend API](https://olympus-hpc.github.io/proteus/user/llvmir-frontend/) |
 | MLIR frontend API | [MLIR Frontend API](https://olympus-hpc.github.io/proteus/user/mlir-frontend/) |
 | DSL API | [DSL API](https://olympus-hpc.github.io/proteus/user/dsl/) |
 

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(pybind11 CONFIG REQUIRED)
 set(PROTEUS_PYTHON_SOURCES
   PythonBindings.cpp
   CppBindings.cpp
+  LLVMIRBindings.cpp
 )
 set(PROTEUS_PYTHON_PACKAGE_SOURCE_DIR
   "${PROJECT_SOURCE_DIR}/python/proteus")

--- a/bindings/python/LLVMIRBindings.cpp
+++ b/bindings/python/LLVMIRBindings.cpp
@@ -1,0 +1,43 @@
+#include "PythonBindings.h"
+
+#include "proteus/LLVMIRJitModule.h"
+
+namespace proteus_python {
+namespace {
+
+class LLVMIRModule final : public ModuleBase {
+  // Owns the concrete LLVM IR JIT implementation behind the shared Python ABI.
+  proteus::LLVMIRJitModule M;
+
+public:
+  LLVMIRModule(const std::string &Target, const std::string &Code)
+      : M(Target, Code) {}
+
+  // Route the generic binding entrypoints to the LLVM IR-backed implementation.
+  void compile(bool Verify) override { M.compile(Verify); }
+  void *getFunctionAddress(const std::string &Name) override {
+    return M.getFunctionAddress(Name);
+  }
+  proteus::TargetModelType getTargetModel() const override {
+    return M.getTargetModel();
+  }
+  void *getKernelAddress(const std::string &Name) override {
+    // The concrete module enforces that kernels only come from device targets.
+    return M.getKernelAddress(Name);
+  }
+  proteus::DispatchResult launch(void *KernelFunc, LaunchDims GridDim,
+                                 LaunchDims BlockDim, void *KernelArgs[],
+                                 uint64_t ShmemSize, void *Stream) override {
+    return M.launch(KernelFunc, GridDim, BlockDim, KernelArgs, ShmemSize,
+                    Stream);
+  }
+};
+
+} // namespace
+
+std::shared_ptr<ModuleBase> createLLVMIRModule(const std::string &Target,
+                                               const std::string &Code) {
+  return std::make_shared<LLVMIRModule>(Target, Code);
+}
+
+} // namespace proteus_python

--- a/bindings/python/PythonBindings.cpp
+++ b/bindings/python/PythonBindings.cpp
@@ -359,6 +359,12 @@ Module compile(py::object Source, const std::string &Frontend,
   std::shared_ptr<ModuleBase> Impl;
   if (Frontend == "cpp") {
     Impl = createCppModule(Target, Code, ExtraArgs, Compiler);
+  } else if (Frontend == "llvmir") {
+    if (Compiler != "clang")
+      throw py::value_error("LLVMIR frontend does not support compiler='nvcc'");
+    if (!ExtraArgs.empty())
+      throw py::value_error("LLVMIR frontend does not support extra_args");
+    Impl = createLLVMIRModule(Target, Code);
   } else if (Frontend == "mlir") {
     if (Compiler != "clang")
       throw py::value_error("MLIR frontend does not support compiler='nvcc'");
@@ -370,7 +376,7 @@ Module compile(py::object Source, const std::string &Frontend,
     throw py::value_error("MLIR frontend requires PROTEUS_ENABLE_MLIR");
 #endif
   } else {
-    throw py::value_error("frontend must be 'cpp' or 'mlir'");
+    throw py::value_error("frontend must be 'cpp', 'llvmir', or 'mlir'");
   }
   Impl->compile(Verify);
   return Module(std::move(Impl));

--- a/bindings/python/PythonBindings.h
+++ b/bindings/python/PythonBindings.h
@@ -49,6 +49,10 @@ createCppModule(const std::string &Target, const std::string &Code,
                 const std::vector<std::string> &ExtraArgs,
                 const std::string &Compiler);
 
+// Builds a module directly from LLVM IR source for the requested target.
+std::shared_ptr<ModuleBase> createLLVMIRModule(const std::string &Target,
+                                               const std::string &Code);
+
 #if PROTEUS_ENABLE_MLIR
 // Builds a module from MLIR source for the requested backend target.
 std::shared_ptr<ModuleBase> createMLIRModule(const std::string &Target,

--- a/bindings/python/tests/CMakeLists.txt
+++ b/bindings/python/tests/CMakeLists.txt
@@ -20,6 +20,22 @@ add_test(
 set_property(TEST python_host_cpp_validation PROPERTY ENVIRONMENT ${PROTEUS_PYTHON_TEST_ENV})
 set_property(TEST python_host_cpp_validation PROPERTY LABELS "python")
 
+add_test(
+  NAME python_host_llvmir_smoke
+  COMMAND ${Python3_EXECUTABLE}
+          ${CMAKE_CURRENT_SOURCE_DIR}/test_host_llvmir_smoke.py
+)
+set_property(TEST python_host_llvmir_smoke PROPERTY ENVIRONMENT ${PROTEUS_PYTHON_TEST_ENV})
+set_property(TEST python_host_llvmir_smoke PROPERTY LABELS "python")
+
+add_test(
+  NAME python_host_llvmir_validation
+  COMMAND ${Python3_EXECUTABLE}
+          ${CMAKE_CURRENT_SOURCE_DIR}/test_host_llvmir_validation.py
+)
+set_property(TEST python_host_llvmir_validation PROPERTY ENVIRONMENT ${PROTEUS_PYTHON_TEST_ENV})
+set_property(TEST python_host_llvmir_validation PROPERTY LABELS "python")
+
 if(PROTEUS_ENABLE_CUDA OR PROTEUS_ENABLE_HIP)
   # GPU C++ frontend coverage only makes sense when a device backend is enabled.
   add_test(

--- a/bindings/python/tests/test_host_cpp_validation.py
+++ b/bindings/python/tests/test_host_cpp_validation.py
@@ -22,7 +22,7 @@ def main():
     expect_raises(
         ValueError,
         lambda: proteus.compile(source, frontend="nope", target="host"),
-        "frontend must be 'cpp' or 'mlir'",
+        "frontend must be 'cpp', 'llvmir', or 'mlir'",
     )
     expect_raises(
         ValueError,

--- a/bindings/python/tests/test_host_llvmir_smoke.py
+++ b/bindings/python/tests/test_host_llvmir_smoke.py
@@ -1,0 +1,39 @@
+import pathlib
+import tempfile
+
+import proteus
+
+
+def main():
+    source = r"""
+define i32 @forty_two() {
+entry:
+  ret i32 42
+}
+
+define i32 @plus1(i32 %x) {
+entry:
+  %sum = add i32 %x, 1
+  ret i32 %sum
+}
+"""
+
+    mod = proteus.compile(source, frontend="llvmir", target="host")
+    assert mod.get_function_address("forty_two") != 0
+    plus1 = mod.get_function("plus1", restype=proteus.i32, argtypes=[proteus.i32])
+    assert repr(plus1) == "<proteus.Function name='plus1' restype=proteus.i32 argtypes=[proteus.i32]>"
+    assert plus1(41) == 42
+    assert proteus.compile(source, frontend="llvmir").get_function_address("forty_two") != 0
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = pathlib.Path(tmpdir) / "kernel.ll"
+        path.write_text(source)
+        mod = proteus.compile(path, frontend="llvmir", target="host")
+        assert mod.get_function_address("forty_two") != 0
+        assert mod.get_function("plus1", restype=proteus.i32, argtypes=[proteus.i32])(41) == 42
+
+    print("python_host_llvmir_smoke: ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/bindings/python/tests/test_host_llvmir_validation.py
+++ b/bindings/python/tests/test_host_llvmir_validation.py
@@ -1,0 +1,28 @@
+import proteus
+
+from test_support import expect_raises
+
+
+def main():
+    source = "define i32 @forty_two() { ret i32 42 }"
+
+    expect_raises(
+        ValueError,
+        lambda: proteus.compile(
+            source, frontend="llvmir", target="host", compiler="nvcc"
+        ),
+        "LLVMIR frontend does not support compiler='nvcc'",
+    )
+    expect_raises(
+        ValueError,
+        lambda: proteus.compile(
+            source, frontend="llvmir", target="host", extra_args=["-O3"]
+        ),
+        "LLVMIR frontend does not support extra_args",
+    )
+
+    print("python_host_llvmir_validation: ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/user/interface.md
+++ b/docs/user/interface.md
@@ -1,7 +1,7 @@
 # User Interface
 
-Proteus offers four ways to define JIT work.
-All four eventually feed the same runtime specialization, caching, and
+Proteus offers five ways to define JIT work.
+All five eventually feed the same runtime specialization, caching, and
 execution pipeline, but they differ in how JIT code is described and in their
 build-time requirements.
 
@@ -9,6 +9,7 @@ build-time requirements.
 | --- | --- | --- | --- | --- |
 | [Code Annotations](annotations.md) | Incremental adoption in existing host, CUDA, or HIP code | Values, arrays, objects, and launch configuration | No | Application must be compiled with Clang |
 | [C++ Frontend API](cpp-frontend.md) | Source-string JIT, runtime template instantiation, and compiler control | Values, arrays, objects, and launch configuration | Yes | Application can be compiled with any compatible compiler |
+| [LLVM IR Frontend API](llvmir-frontend.md) | Direct LLVM IR JIT from text or bitcode | Encoded directly in the provided LLVM IR | No | Application can be compiled with any compatible compiler |
 | [MLIR Frontend API](mlir-frontend.md) | Source-string MLIR JIT and direct access to MLIR lowering | Encoded directly in the provided MLIR source | No | Application can be compiled with any compatible compiler |
 | [DSL API](dsl.md) | Programmatic IR construction and advanced runtime code generation | Values, arrays, and launch configuration | No | Application can be compiled with any compatible compiler |
 
@@ -16,6 +17,7 @@ For more detail on each path:
 
 - [Code Annotations](annotations.md)
 - [C++ Frontend API](cpp-frontend.md)
+- [LLVM IR Frontend API](llvmir-frontend.md)
 - [MLIR Frontend API](mlir-frontend.md)
 - [DSL API](dsl.md)
 

--- a/docs/user/llvmir-frontend.md
+++ b/docs/user/llvmir-frontend.md
@@ -1,0 +1,134 @@
+# LLVM IR Frontend API
+
+The LLVM IR frontend API lets you provide LLVM IR directly as text or bitcode
+and compile it through Proteus at runtime.
+It is intended for users who already produce LLVM IR and want Proteus to handle
+target selection, caching, and execution without going through the C++ or MLIR
+frontends.
+
+Unlike the annotation interface, this path does not require compiling the
+application with Clang.
+The application can be built with any compatible compiler because Proteus parses
+the LLVM IR at runtime.
+
+If you want to provide C++ source strings instead of LLVM IR, see the
+[C++ frontend API](cpp-frontend.md).
+If you want direct access to Proteus's MLIR lowering path, see the
+[MLIR frontend API](mlir-frontend.md).
+If you want to construct IR programmatically rather than provide source text,
+see the [DSL API](dsl.md).
+
+## Overview
+
+`LLVMIRJitModule` is constructed from a target string plus LLVM IR input:
+
+- target `"host"`, `"cuda"`, or `"hip"`
+- LLVM IR source text or LLVM bitcode bytes
+- optional `LLVMIRInputKind`, which defaults to `LLVMIRInputKind::Auto`
+
+`LLVMIRInputKind` controls how the input is parsed:
+
+- `Auto`: try bitcode first, then fall back to text IR
+- `TextIR`: require textual LLVM IR
+- `Bitcode`: require LLVM bitcode
+
+For host targets, retrieve entry points with `getFunction()` and execute them
+with `run()`.
+For CUDA and HIP targets, retrieve device entry points with `getKernel()` and
+launch them with grid dimensions, block dimensions, dynamic shared memory size,
+stream, and kernel arguments.
+
+If the input module omits the target triple or data layout, Proteus fills them
+in for the selected target before compilation.
+
+## Host Example
+
+Here is a minimal host example that compiles an LLVM IR function and calls it
+from C++:
+
+```cpp
+#include <proteus/LLVMIRJitModule.h>
+
+using namespace proteus;
+
+static constexpr const char *Code = R"llvm(
+define i32 @add(i32 %a, i32 %b) {
+entry:
+  %sum = add i32 %a, %b
+  ret i32 %sum
+}
+)llvm";
+
+LLVMIRJitModule Module{"host", Code};
+auto Add = Module.getFunction<int(int, int)>("add");
+
+int Result = Add.run(40, 2);
+```
+
+The symbol name passed to `getFunction()` must match the LLVM function symbol.
+
+## GPU Example
+
+GPU modules use regular LLVM IR with a device target triple and a kernel entry
+point that is valid for the selected backend.
+
+CUDA example:
+
+```cpp
+#include <proteus/LLVMIRJitModule.h>
+
+using namespace proteus;
+
+static constexpr const char *Code = R"llvm(
+target triple = "nvptx64-nvidia-cuda"
+
+define ptx_kernel void @write42(ptr addrspace(1) %out) {
+entry:
+  store i32 42, ptr addrspace(1) %out, align 4
+  ret void
+}
+
+!nvvm.annotations = !{!0}
+!0 = !{ptr @write42, !"kernel", i32 1}
+)llvm";
+
+LLVMIRJitModule Module{"cuda", Code};
+auto Write42 = Module.getKernel<void(int *)>("write42");
+
+int *DeviceBuffer = ...;
+Write42.launch(
+  /* GridDim */ {1, 1, 1},
+  /* BlockDim */ {1, 1, 1},
+  /* ShmemSize */ 0,
+  /* Stream */ nullptr,
+  DeviceBuffer);
+```
+
+Use target `"hip"` instead of `"cuda"` to compile for HIP, assuming Proteus
+was built with HIP support.
+The input must already be LLVM IR that is valid for HIP execution, such as IR
+with an AMDGPU target triple and compatible kernel conventions.
+
+## Python Bindings
+
+The Python bindings expose the same frontend through
+`proteus.compile(..., frontend="llvmir")`.
+
+```python
+import proteus
+
+source = r"""
+define i32 @plus1(i32 %x) {
+entry:
+  %sum = add i32 %x, 1
+  ret i32 %sum
+}
+"""
+
+mod = proteus.compile(source, frontend="llvmir", target="host")
+plus1 = mod.get_function("plus1", restype=proteus.i32, argtypes=[proteus.i32])
+assert plus1(41) == 42
+```
+
+In the current Python API, LLVM IR input is provided as text through a string
+or a path to a `.ll` file.

--- a/include/proteus/LLVMIRJitModule.h
+++ b/include/proteus/LLVMIRJitModule.h
@@ -1,0 +1,144 @@
+#ifndef PROTEUS_LLVMIRJITMODULE_H
+#define PROTEUS_LLVMIRJITMODULE_H
+
+#include "proteus/Frontend/Dispatcher.h"
+#include "proteus/Frontend/TargetModel.h"
+#include "proteus/JitFuncAttribute.h"
+
+#include <memory>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+namespace proteus {
+
+struct CompiledLibrary;
+class HashT;
+
+enum class LLVMIRInputKind {
+  Auto,
+  TextIR,
+  Bitcode,
+};
+
+class LLVMIRJitModule {
+private:
+  TargetModelType TargetModel;
+  std::string Code;
+  LLVMIRInputKind InputKind;
+  Dispatcher &Dispatch;
+  std::unique_ptr<HashT> ModuleHash;
+  std::unique_ptr<CompiledLibrary> Library;
+  bool IsCompiled = false;
+
+public:
+  explicit LLVMIRJitModule(TargetModelType TargetModel, const std::string &Code,
+                           LLVMIRInputKind InputKind = LLVMIRInputKind::Auto);
+  explicit LLVMIRJitModule(const std::string &Target, const std::string &Code,
+                           LLVMIRInputKind InputKind = LLVMIRInputKind::Auto);
+  ~LLVMIRJitModule();
+
+  void compile(bool Verify = false);
+
+  // Expose the target model so higher-level bindings can reject invalid API
+  // combinations before dispatch.
+  TargetModelType getTargetModel() const { return TargetModel; }
+
+  void setFuncAttribute(void *KernelFunc, JitFuncAttribute Attr, int Value);
+  void *getFunctionAddress(const std::string &Name);
+  void *getKernelAddress(const std::string &Name) {
+    if (!IsCompiled)
+      compile();
+
+    if (TargetModel == TargetModelType::HOST)
+      reportFatalError(
+          "Error: getKernelAddress() applies only to device modules");
+
+    // Kernel symbols are loaded through the same compiled image as host
+    // function symbols once target validation is complete.
+    return getFunctionAddress(Name);
+  }
+
+  DispatchResult launch(void *KernelFunc, LaunchDims GridDim,
+                        LaunchDims BlockDim, void *KernelArgs[],
+                        uint64_t ShmemSize, void *Stream);
+
+  CompiledLibrary &getLibrary() {
+    if (!IsCompiled)
+      compile();
+
+    if (!Library)
+      reportFatalError("Expected non-null library after compilation");
+
+    return *Library;
+  }
+
+  template <typename Sig> struct FunctionHandle;
+  template <typename RetT, typename... ArgT>
+  struct FunctionHandle<RetT(ArgT...)> {
+    LLVMIRJitModule &M;
+    void *FuncPtr;
+
+    explicit FunctionHandle(LLVMIRJitModule &M, void *FuncPtr)
+        : M(M), FuncPtr(FuncPtr) {}
+
+    RetT run(ArgT... Args) {
+      if constexpr (std::is_void_v<RetT>) {
+        M.Dispatch.template run<RetT(ArgT...)>(FuncPtr,
+                                               std::forward<ArgT>(Args)...);
+      } else {
+        return M.Dispatch.template run<RetT(ArgT...)>(
+            FuncPtr, std::forward<ArgT>(Args)...);
+      }
+    }
+  };
+
+  template <typename Sig> struct KernelHandle;
+  template <typename RetT, typename... ArgT>
+  struct KernelHandle<RetT(ArgT...)> {
+    LLVMIRJitModule &M;
+    void *FuncPtr = nullptr;
+
+    explicit KernelHandle(LLVMIRJitModule &M, void *FuncPtr)
+        : M(M), FuncPtr(FuncPtr) {
+      static_assert(std::is_void_v<RetT>, "Kernel function must return void");
+    }
+
+    void setFuncAttribute(JitFuncAttribute Attr, int Value) {
+      M.setFuncAttribute(FuncPtr, Attr, Value);
+    }
+
+    auto launch(LaunchDims GridDim, LaunchDims BlockDim, uint64_t ShmemSize,
+                void *Stream, ArgT... Args) {
+      void *Ptrs[sizeof...(ArgT)] = {(void *)&Args...};
+      return M.launch(FuncPtr, GridDim, BlockDim, Ptrs, ShmemSize, Stream);
+    }
+  };
+
+  template <typename Sig>
+  FunctionHandle<Sig> getFunction(const std::string &Name) {
+    if (!IsCompiled)
+      compile();
+
+    if (!isHostTargetModel(TargetModel))
+      reportFatalError("Error: getFunction() applies only to host modules");
+
+    void *FuncPtr = getFunctionAddress(Name);
+    return FunctionHandle<Sig>(*this, FuncPtr);
+  }
+
+  template <typename Sig> KernelHandle<Sig> getKernel(const std::string &Name) {
+    if (!IsCompiled)
+      compile();
+
+    if (TargetModel == TargetModelType::HOST)
+      reportFatalError("Error: getKernel() applies only to device modules");
+
+    void *FuncPtr = getFunctionAddress(Name);
+    return KernelHandle<Sig>(*this, FuncPtr);
+  }
+};
+
+} // namespace proteus
+
+#endif // PROTEUS_LLVMIRJITMODULE_H

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,7 @@ nav:
           - Overview: user/interface.md
           - Code Annotations: user/annotations.md
           - C++ Frontend API: user/cpp-frontend.md
+          - LLVM IR Frontend API: user/llvmir-frontend.md
           - MLIR Frontend API: user/mlir-frontend.md
           - DSL API: user/dsl.md
       - Runtime Configuration: user/config.md

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -13,6 +13,7 @@ set(SOURCES
   Frontend/CppJitCompilerClang.cpp
   Frontend/JitFuncAttribute.cpp
   Frontend/CppJitModule.cpp
+  Frontend/LLVMIRJitModule.cpp
   Frontend/CppJitCompilerNvcc.cpp
   Frontend/Builtins.cpp
   Frontend/Dispatcher.cpp

--- a/src/runtime/Frontend/LLVMIRJitModule.cpp
+++ b/src/runtime/Frontend/LLVMIRJitModule.cpp
@@ -15,6 +15,7 @@
 #include <llvm/Support/MemoryBuffer.h>
 #include <llvm/Support/SourceMgr.h>
 #include <llvm/TargetParser/Host.h>
+#include <llvm/TargetParser/Triple.h>
 
 namespace proteus {
 namespace {
@@ -94,7 +95,11 @@ void LLVMIRJitModule::compile(bool Verify) {
     reportFatalError("LLVMIRJitModule: expected non-null parsed LLVM module");
 
   if (Module->getTargetTriple().empty())
+#if LLVM_VERSION_MAJOR >= 22
+    Module->setTargetTriple(llvm::Triple(getTargetTriple(TargetModel)));
+#else
     Module->setTargetTriple(getTargetTriple(TargetModel));
+#endif
 
   if (Module->getDataLayout().isDefault()) {
     const llvm::StringRef Arch = isHostTargetModel(TargetModel)

--- a/src/runtime/Frontend/LLVMIRJitModule.cpp
+++ b/src/runtime/Frontend/LLVMIRJitModule.cpp
@@ -1,0 +1,137 @@
+#include "proteus/LLVMIRJitModule.h"
+
+#include "proteus/TimeTracing.h"
+#include "proteus/impl/CompiledLibrary.h"
+#include "proteus/impl/CoreLLVM.h"
+#include "proteus/impl/Frontend/JitFuncAttribute.h"
+#include "proteus/impl/Hashing.h"
+
+#include <llvm/Bitcode/BitcodeReader.h>
+#include <llvm/IR/LLVMContext.h>
+#include <llvm/IR/Module.h>
+#include <llvm/IR/Verifier.h>
+#include <llvm/IRReader/IRReader.h>
+#include <llvm/Support/Error.h>
+#include <llvm/Support/MemoryBuffer.h>
+#include <llvm/Support/SourceMgr.h>
+#include <llvm/TargetParser/Host.h>
+
+namespace proteus {
+namespace {
+
+std::unique_ptr<llvm::Module> parseLLVMIRModule(const std::string &Code,
+                                                LLVMIRInputKind InputKind,
+                                                llvm::LLVMContext &Context) {
+  llvm::MemoryBufferRef Buffer(Code, "LLVMIRJitModule");
+
+  auto ParseBitcode = [&]() -> std::unique_ptr<llvm::Module> {
+    auto Parsed = llvm::parseBitcodeFile(Buffer, Context);
+    if (!Parsed) {
+      llvm::consumeError(Parsed.takeError());
+      return nullptr;
+    }
+    return std::move(*Parsed);
+  };
+
+  if (InputKind == LLVMIRInputKind::Bitcode) {
+    auto Parsed = llvm::parseBitcodeFile(Buffer, Context);
+    if (!Parsed)
+      reportFatalError("LLVMIRJitModule: failed to parse bitcode: " +
+                       llvm::toString(Parsed.takeError()));
+    return std::move(*Parsed);
+  }
+
+  if (InputKind == LLVMIRInputKind::Auto) {
+    if (auto ParsedBitcode = ParseBitcode()) {
+      return ParsedBitcode;
+    }
+  }
+
+  llvm::SMDiagnostic Diag;
+  auto ParsedIR = llvm::parseIR(Buffer, Diag, Context);
+  if (!ParsedIR) {
+    reportFatalError("LLVMIRJitModule: failed to parse LLVM IR: " +
+                     Diag.getMessage().str());
+  }
+
+  return ParsedIR;
+}
+
+} // namespace
+
+LLVMIRJitModule::LLVMIRJitModule(TargetModelType TargetModel,
+                                 const std::string &Code,
+                                 LLVMIRInputKind InputKind)
+    : TargetModel(TargetModel), Code(Code), InputKind(InputKind),
+      Dispatch(Dispatcher::getDispatcher(TargetModel)) {
+  // Hash the raw input, target model, and codegen config because each can
+  // change the compiled artifact.
+  ModuleHash = std::make_unique<HashT>(
+      hash(static_cast<int>(TargetModel), Code, Config::get().getCGConfig()));
+}
+
+LLVMIRJitModule::LLVMIRJitModule(const std::string &Target,
+                                 const std::string &Code,
+                                 LLVMIRInputKind InputKind)
+    : LLVMIRJitModule(parseTargetModel(Target), Code, InputKind) {}
+
+LLVMIRJitModule::~LLVMIRJitModule() = default;
+
+void LLVMIRJitModule::compile(bool Verify) {
+  TIMESCOPE(LLVMIRJitModule, compile);
+
+  if (IsCompiled)
+    return;
+
+  if ((Library = Dispatch.lookupCompiledLibrary(*ModuleHash))) {
+    IsCompiled = true;
+    return;
+  }
+
+  auto Context = std::make_unique<llvm::LLVMContext>();
+  auto Module = parseLLVMIRModule(Code, InputKind, *Context);
+  if (!Module)
+    reportFatalError("LLVMIRJitModule: expected non-null parsed LLVM module");
+
+  if (Module->getTargetTriple().empty())
+    Module->setTargetTriple(getTargetTriple(TargetModel));
+
+  if (Module->getDataLayout().isDefault()) {
+    const llvm::StringRef Arch = isHostTargetModel(TargetModel)
+                                     ? llvm::sys::getHostCPUName()
+                                     : Dispatch.getDeviceArch();
+    auto TMExpected = detail::createTargetMachine(*Module, Arch);
+    if (!TMExpected)
+      reportFatalError("LLVMIRJitModule: failed to create target machine");
+    Module->setDataLayout((*TMExpected)->createDataLayout());
+  }
+
+  if (Verify && verifyModule(*Module, &llvm::errs()))
+    reportFatalError("Broken module found, JIT compilation aborted!");
+
+  Library = std::make_unique<CompiledLibrary>(
+      Dispatch.compile(std::move(Context), std::move(Module), *ModuleHash));
+  IsCompiled = true;
+}
+
+void LLVMIRJitModule::setFuncAttribute(void *KernelFunc, JitFuncAttribute Attr,
+                                       int Value) {
+  proteus::setFuncAttribute(TargetModel, KernelFunc, Attr, Value);
+}
+
+void *LLVMIRJitModule::getFunctionAddress(const std::string &Name) {
+  TIMESCOPE(LLVMIRJitModule, getFunctionAddress);
+  if (!ModuleHash)
+    reportFatalError("LLVMIRJitModule: expected module hash after compilation");
+  return Dispatch.getFunctionAddress(Name, *ModuleHash, getLibrary());
+}
+
+DispatchResult LLVMIRJitModule::launch(void *KernelFunc, LaunchDims GridDim,
+                                       LaunchDims BlockDim, void *KernelArgs[],
+                                       uint64_t ShmemSize, void *Stream) {
+  TIMESCOPE(LLVMIRJitModule, launch);
+  return Dispatch.launch(KernelFunc, GridDim, BlockDim, KernelArgs, ShmemSize,
+                         Stream);
+}
+
+} // namespace proteus

--- a/tests/frontend/CMakeLists.txt
+++ b/tests/frontend/CMakeLists.txt
@@ -8,3 +8,5 @@ endif()
 if(PROTEUS_ENABLE_MLIR)
     add_subdirectory(mlir)
 endif()
+
+add_subdirectory(llvmir)

--- a/tests/frontend/llvmir/CMakeLists.txt
+++ b/tests/frontend/llvmir/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_subdirectory(cpu)
+
+if(PROTEUS_ENABLE_CUDA OR PROTEUS_ENABLE_HIP)
+  add_subdirectory(gpu)
+endif()

--- a/tests/frontend/llvmir/cpu/CMakeLists.txt
+++ b/tests/frontend/llvmir/cpu/CMakeLists.txt
@@ -1,0 +1,55 @@
+function(CREATE_LLVMIR_CPU_LIT_TEST exe check_source)
+  add_executable(${exe} ${check_source} ${ARGN})
+  target_link_libraries(${exe} PUBLIC proteusFrontend)
+
+  # Consumers need to add rdynamic when linking so that ORC JIT can link JIT
+  # modules with exported symbols.
+  target_link_options(${exe} PRIVATE $<LINK_ONLY:-rdynamic>)
+
+  add_test(NAME ${exe}
+           COMMAND ${LIT} -vv -D FILECHECK=${FILECHECK} -D LLVM_AS=${LLVM_AS}
+                   ${check_source})
+  set_property(TEST ${exe} PROPERTY LABELS "frontend-llvmir;frontend-llvmir-cpu")
+endfunction()
+
+find_program(LLVM_AS llvm-as
+  PATHS ${LLVM_BINARY_DIR}/bin ${LLVM_TOOLS_BINARY_DIR})
+
+if(NOT LLVM_AS)
+  message(FATAL_ERROR "Testing requires llvm-as to be installed")
+endif()
+
+file(
+  WRITE ${CMAKE_CURRENT_BINARY_DIR}/lit.cfg.py
+  "
+import lit.formats
+import os
+import tempfile
+import atexit
+import shutil
+
+config.name = 'LIT LLVMIR CPU tests'
+config.test_format = lit.formats.ShTest(True)
+config.environment = os.environ.copy()
+
+config.suffixes = ['.cpp']
+config.test_source_root = '${CMAKE_CURRENT_SOURCE_DIR}'
+# Create a unique temp exec_root to avoid races on lit_test_times.txt
+exec_root = tempfile.mkdtemp(prefix='lit.tmp.', dir='${CMAKE_CURRENT_BINARY_DIR}')
+config.test_exec_root = exec_root
+atexit.register(lambda: shutil.rmtree(exec_root, ignore_errors=False))
+
+FILECHECK = lit_config.params['FILECHECK']
+LLVM_AS = lit_config.params['LLVM_AS']
+config.substitutions.append(('%FILECHECK', FILECHECK))
+config.substitutions.append(('%llvm_as', LLVM_AS))
+config.substitutions.append(('%build', '${CMAKE_CURRENT_BINARY_DIR}'))
+")
+
+set(LLVMIR_CPU_LIT_TESTS
+    llvmir_jit_module_source
+    llvmir_jit_module_bitcode)
+
+foreach(exe IN LISTS LLVMIR_CPU_LIT_TESTS)
+  CREATE_LLVMIR_CPU_LIT_TEST(${exe} ${exe}.cpp)
+endforeach()

--- a/tests/frontend/llvmir/cpu/llvmir_jit_module_bitcode.cpp
+++ b/tests/frontend/llvmir/cpu/llvmir_jit_module_bitcode.cpp
@@ -1,0 +1,47 @@
+// clang-format off
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: %llvm_as %S/llvmir_jit_module_bitcode_input.ll -o %t.module.bc
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/llvmir_jit_module_bitcode %t.module.bc | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// Second run uses the object cache.
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/llvmir_jit_module_bitcode %t.module.bc | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
+// clang-format on
+
+#include <cassert>
+#include <cstdio>
+#include <fstream>
+#include <iterator>
+#include <string>
+
+#include <proteus/LLVMIRJitModule.h>
+
+using namespace proteus;
+
+int main(int argc, char **argv) {
+  if (argc != 2) {
+    std::fprintf(stderr, "Expected a single bitcode input path\n");
+    return 1;
+  }
+
+  std::ifstream Input(argv[1], std::ios::binary);
+  assert(Input && "Failed to open bitcode file");
+
+  std::string Code((std::istreambuf_iterator<char>(Input)),
+                   std::istreambuf_iterator<char>());
+
+  LLVMIRJitModule M("host", Code, LLVMIRInputKind::Bitcode);
+  auto Add = M.getFunction<int(int, int)>("add");
+
+  const int Result = Add.run(40, 2);
+  std::printf("llvmir_jit_module_bitcode: Result=%d\n", Result);
+  assert(Result == 42 &&
+         "LLVMIRJitModule bitcode execution returned wrong result");
+
+  return 0;
+}
+
+// clang-format off
+// CHECK: llvmir_jit_module_bitcode: Result=42
+// CHECK-FIRST: [proteus][DispatcherHost] StorageCache rank 0 hits 0 accesses 1
+// CHECK-SECOND: [proteus][DispatcherHost] StorageCache rank 0 hits 1 accesses 1
+// clang-format on

--- a/tests/frontend/llvmir/cpu/llvmir_jit_module_bitcode_input.ll
+++ b/tests/frontend/llvmir/cpu/llvmir_jit_module_bitcode_input.ll
@@ -1,0 +1,5 @@
+define i32 @add(i32 %a, i32 %b) {
+entry:
+  %sum = add i32 %a, %b
+  ret i32 %sum
+}

--- a/tests/frontend/llvmir/cpu/llvmir_jit_module_source.cpp
+++ b/tests/frontend/llvmir/cpu/llvmir_jit_module_source.cpp
@@ -1,0 +1,40 @@
+// clang-format off
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/llvmir_jit_module_source | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// Second run uses the object cache.
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/llvmir_jit_module_source | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
+// clang-format on
+
+#include <cassert>
+#include <cstdio>
+
+#include <proteus/LLVMIRJitModule.h>
+
+using namespace proteus;
+
+int main() {
+  static constexpr const char *Code = R"llvm(
+define i32 @add(i32 %a, i32 %b) {
+entry:
+  %sum = add i32 %a, %b
+  ret i32 %sum
+}
+)llvm";
+
+  LLVMIRJitModule M("host", Code);
+  auto Add = M.getFunction<int(int, int)>("add");
+
+  const int Result = Add.run(40, 2);
+  std::printf("llvmir_jit_module_source: Result=%d\n", Result);
+  assert(Result == 42 &&
+         "LLVMIRJitModule host execution returned wrong result");
+
+  return 0;
+}
+
+// clang-format off
+// CHECK: llvmir_jit_module_source: Result=42
+// CHECK-FIRST: [proteus][DispatcherHost] StorageCache rank 0 hits 0 accesses 1
+// CHECK-SECOND: [proteus][DispatcherHost] StorageCache rank 0 hits 1 accesses 1
+// clang-format on

--- a/tests/frontend/llvmir/gpu/CMakeLists.txt
+++ b/tests/frontend/llvmir/gpu/CMakeLists.txt
@@ -1,0 +1,73 @@
+if(PROTEUS_ENABLE_HIP)
+  set(PROTEUS_GPU_LANG HIP)
+  enable_language(HIP)
+elseif(PROTEUS_ENABLE_CUDA)
+  set(PROTEUS_GPU_LANG CUDA)
+  if(NOT CMAKE_CUDA_ARCHITECTURES)
+    message(FATAL_ERROR "Set CMAKE_CUDA_ARCHITECTURES to compile for")
+  endif()
+
+  enable_language(CUDA)
+  message(STATUS "CUDA compiler ${CMAKE_CUDA_COMPILER_ID}")
+
+  if(NOT ${CMAKE_CUDA_COMPILER_ID} STREQUAL "Clang")
+    message(FATAL_ERROR "JIT is compatible only with Clang CUDA compilation")
+  endif()
+else()
+  message(FATAL_ERROR "Expected PROTEUS_ENABLE_HIP or PROTEUS_ENABLE_CUDA")
+endif()
+
+function(CREATE_LLVMIR_GPU_LIT_TEST exe check_source)
+  add_executable(${exe}.${PROTEUS_GPU_LANG} ${check_source} ${ARGN})
+  target_link_libraries(${exe}.${PROTEUS_GPU_LANG} PUBLIC proteusFrontend)
+  set_source_files_properties(${check_source} ${ARGN} PROPERTIES
+                              LANGUAGE ${PROTEUS_GPU_LANG})
+
+  add_test(
+    NAME ${exe}.${PROTEUS_GPU_LANG}
+    COMMAND ${LIT} -vv -D EXT=${PROTEUS_GPU_LANG} -D FILECHECK=${FILECHECK}
+            -D LLVM_AS=${LLVM_AS} ${check_source})
+  set_property(TEST ${exe}.${PROTEUS_GPU_LANG}
+               PROPERTY LABELS "frontend-llvmir;frontend-llvmir-gpu")
+endfunction()
+
+find_program(LLVM_AS llvm-as
+  PATHS ${LLVM_BINARY_DIR}/bin ${LLVM_TOOLS_BINARY_DIR})
+
+if(NOT LLVM_AS)
+  message(FATAL_ERROR "Testing requires llvm-as to be installed")
+endif()
+
+file(
+  WRITE ${CMAKE_CURRENT_BINARY_DIR}/lit.cfg.py
+  "
+import lit.formats
+import os
+import tempfile
+import atexit
+import shutil
+
+config.name = 'LIT LLVMIR GPU tests'
+config.test_format = lit.formats.ShTest(True)
+config.environment = os.environ.copy()
+
+config.suffixes = ['.cpp']
+config.test_source_root = '${CMAKE_CURRENT_SOURCE_DIR}'
+# Create a unique temp exec_root to avoid races on lit_test_times.txt
+exec_root = tempfile.mkdtemp(prefix='lit.tmp.', dir='${CMAKE_CURRENT_BINARY_DIR}')
+config.test_exec_root = exec_root
+atexit.register(lambda: shutil.rmtree(exec_root, ignore_errors=False))
+
+ext = lit_config.params['EXT']
+FILECHECK = lit_config.params['FILECHECK']
+LLVM_AS = lit_config.params['LLVM_AS']
+config.substitutions.append(('%ext', ext))
+config.substitutions.append(('%FILECHECK', FILECHECK))
+config.substitutions.append(('%llvm_as', LLVM_AS))
+config.substitutions.append(('%build', '${CMAKE_CURRENT_BINARY_DIR}'))
+")
+
+CREATE_LLVMIR_GPU_LIT_TEST(llvmir_gpu_jit_module_source
+             llvmir_gpu_jit_module_source.cpp)
+CREATE_LLVMIR_GPU_LIT_TEST(llvmir_gpu_jit_module_bitcode
+             llvmir_gpu_jit_module_bitcode.cpp)

--- a/tests/frontend/llvmir/gpu/llvmir_gpu_jit_module_bitcode.cpp
+++ b/tests/frontend/llvmir/gpu/llvmir_gpu_jit_module_bitcode.cpp
@@ -1,0 +1,70 @@
+// clang-format off
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: %llvm_as %S/llvmir_gpu_jit_module_bitcode_input.%ext.ll -o %t.module.bc
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/llvmir_gpu_jit_module_bitcode.%ext %t.module.bc | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// Second run uses the object cache.
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/llvmir_gpu_jit_module_bitcode.%ext %t.module.bc | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
+// clang-format on
+
+#include <cassert>
+#include <cstdio>
+#include <fstream>
+#include <iterator>
+#include <string>
+
+#include <proteus/LLVMIRJitModule.h>
+
+#include "../../../gpu/gpu_common.h"
+
+using namespace proteus;
+
+int main(int argc, char **argv) {
+#if defined(PROTEUS_ENABLE_CUDA)
+  const char *Target = "cuda";
+#elif defined(PROTEUS_ENABLE_HIP)
+  const char *Target = "hip";
+#else
+  return 0;
+#endif
+
+  if (argc != 2) {
+    std::fprintf(stderr, "Expected a single bitcode input path\n");
+    return 1;
+  }
+
+  std::ifstream Input(argv[1], std::ios::binary);
+  assert(Input && "Failed to open bitcode file");
+
+  std::string Code((std::istreambuf_iterator<char>(Input)),
+                   std::istreambuf_iterator<char>());
+
+  LLVMIRJitModule M(Target, Code, LLVMIRInputKind::Bitcode);
+  auto Write42 = M.getKernel<void(int *)>("write42");
+
+  int *DeviceBuffer = nullptr;
+  gpuErrCheck(gpuMalloc(reinterpret_cast<void **>(&DeviceBuffer), sizeof(int)));
+
+  int Initial = 0;
+  gpuErrCheck(
+      gpuMemcpy(DeviceBuffer, &Initial, sizeof(int), gpuMemcpyHostToDevice));
+
+  gpuErrCheck(Write42.launch({1, 1, 1}, {1, 1, 1}, 0, nullptr, DeviceBuffer));
+  gpuErrCheck(gpuDeviceSynchronize());
+
+  int Result = -1;
+  gpuErrCheck(
+      gpuMemcpy(&Result, DeviceBuffer, sizeof(int), gpuMemcpyDeviceToHost));
+  std::printf("llvmir_gpu_jit_module_bitcode: Result=%d\n", Result);
+  assert(Result == 42 &&
+         "LLVMIRJitModule GPU bitcode execution returned wrong result");
+
+  gpuErrCheck(gpuFree(DeviceBuffer));
+  return 0;
+}
+
+// clang-format off
+// CHECK: llvmir_gpu_jit_module_bitcode: Result=42
+// CHECK-FIRST: [proteus][Dispatcher{{CUDA|HIP}}] StorageCache rank 0 hits 0 accesses 1
+// CHECK-SECOND: [proteus][Dispatcher{{CUDA|HIP}}] StorageCache rank 0 hits 1 accesses 1
+// clang-format on

--- a/tests/frontend/llvmir/gpu/llvmir_gpu_jit_module_bitcode_input.CUDA.ll
+++ b/tests/frontend/llvmir/gpu/llvmir_gpu_jit_module_bitcode_input.CUDA.ll
@@ -1,0 +1,10 @@
+target triple = "nvptx64-nvidia-cuda"
+
+define ptx_kernel void @write42(ptr addrspace(1) %out) {
+entry:
+  store i32 42, ptr addrspace(1) %out, align 4
+  ret void
+}
+
+!nvvm.annotations = !{!0}
+!0 = !{ptr @write42, !"kernel", i32 1}

--- a/tests/frontend/llvmir/gpu/llvmir_gpu_jit_module_bitcode_input.HIP.ll
+++ b/tests/frontend/llvmir/gpu/llvmir_gpu_jit_module_bitcode_input.HIP.ll
@@ -1,0 +1,9 @@
+target triple = "amdgcn-amd-amdhsa"
+
+define amdgpu_kernel void @write42(ptr addrspace(1) %out) #0 {
+entry:
+  store i32 42, ptr addrspace(1) %out, align 4
+  ret void
+}
+
+attributes #0 = { nounwind }

--- a/tests/frontend/llvmir/gpu/llvmir_gpu_jit_module_source.cpp
+++ b/tests/frontend/llvmir/gpu/llvmir_gpu_jit_module_source.cpp
@@ -1,0 +1,77 @@
+// clang-format off
+// RUN: rm -rf "%t.$$.proteus"
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/llvmir_gpu_jit_module_source.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-FIRST
+// Second run uses the object cache.
+// RUN: PROTEUS_CACHE_DIR="%t.$$.proteus" %build/llvmir_gpu_jit_module_source.%ext | %FILECHECK %s --check-prefixes=CHECK,CHECK-SECOND
+// RUN: rm -rf "%t.$$.proteus"
+// clang-format on
+
+#include <cassert>
+#include <cstdio>
+
+#include <proteus/LLVMIRJitModule.h>
+
+#include "../../../gpu/gpu_common.h"
+
+using namespace proteus;
+
+int main() {
+#if defined(PROTEUS_ENABLE_CUDA)
+  const char *Target = "cuda";
+  static constexpr const char *Code = R"llvm(
+target triple = "nvptx64-nvidia-cuda"
+
+define ptx_kernel void @write42(ptr addrspace(1) %out) {
+entry:
+  store i32 42, ptr addrspace(1) %out, align 4
+  ret void
+}
+
+!nvvm.annotations = !{!0}
+!0 = !{ptr @write42, !"kernel", i32 1}
+)llvm";
+#elif defined(PROTEUS_ENABLE_HIP)
+  const char *Target = "hip";
+  static constexpr const char *Code = R"llvm(
+target triple = "amdgcn-amd-amdhsa"
+
+define amdgpu_kernel void @write42(ptr addrspace(1) %out) #0 {
+entry:
+  store i32 42, ptr addrspace(1) %out, align 4
+  ret void
+}
+
+attributes #0 = { nounwind }
+)llvm";
+#else
+  return 0;
+#endif
+
+  LLVMIRJitModule M(Target, Code);
+  auto Write42 = M.getKernel<void(int *)>("write42");
+
+  int *DeviceBuffer = nullptr;
+  gpuErrCheck(gpuMalloc(reinterpret_cast<void **>(&DeviceBuffer), sizeof(int)));
+
+  int Initial = 0;
+  gpuErrCheck(
+      gpuMemcpy(DeviceBuffer, &Initial, sizeof(int), gpuMemcpyHostToDevice));
+
+  gpuErrCheck(Write42.launch({1, 1, 1}, {1, 1, 1}, 0, nullptr, DeviceBuffer));
+  gpuErrCheck(gpuDeviceSynchronize());
+
+  int Result = -1;
+  gpuErrCheck(
+      gpuMemcpy(&Result, DeviceBuffer, sizeof(int), gpuMemcpyDeviceToHost));
+  std::printf("llvmir_gpu_jit_module_source: Result=%d\n", Result);
+  assert(Result == 42 && "LLVMIRJitModule GPU execution returned wrong result");
+
+  gpuErrCheck(gpuFree(DeviceBuffer));
+  return 0;
+}
+
+// clang-format off
+// CHECK: llvmir_gpu_jit_module_source: Result=42
+// CHECK-FIRST: [proteus][Dispatcher{{CUDA|HIP}}] StorageCache rank 0 hits 0 accesses 1
+// CHECK-SECOND: [proteus][Dispatcher{{CUDA|HIP}}] StorageCache rank 0 hits 1 accesses 1
+// clang-format on


### PR DESCRIPTION
- Add `LLVMIRJitModule` support for compiling host and device LLVM IR from source or bitcode.
- Add CPU and GPU lit coverage for source, bitcode, and cache-hit behavior.
- Add python bindings