### PR TITLE
Resolve HIP bitcode assets from ROCm at runtime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,29 +82,7 @@ if(PROTEUS_ENABLE_HIP)
   message(STATUS "hiprtc Version: ${hiprtc_VERSION}")
   if(hip_VERSION VERSION_LESS "6.2.0")
     message(FATAL_ERROR "HIP found: ${hip_VERSION} is less than minimum required version 6.2.0.")
-	endif()
-
-	# Find ROCm device library bitcode (ocml/ockl/oclc_*), typically under
-	# <ROCm>/amdgcn/bitcode. We rely on the ROCm-provided CMake package
-	# (rocm-device-libs) rather than hard-coding filesystem layout.
-	find_package(AMDDeviceLibs REQUIRED CONFIG
-	  HINTS
-	    ${HIP_PACKAGE_PREFIX_DIR}
-	    ${HIP_PACKAGE_PREFIX_DIR}/..
-	    ${LLVM_INSTALL_DIR}
-	    ${LLVM_INSTALL_DIR}/..
-	)
-	message(STATUS "Found AMDDeviceLibs package in: ${AMDDeviceLibs_DIR}")
-	if(NOT TARGET ocml)
-	  message(FATAL_ERROR "AMDDeviceLibs package did not define expected imported target: ocml")
-	endif()
-	get_target_property(_ocml_bc ocml IMPORTED_LOCATION)
-	if(NOT _ocml_bc OR NOT EXISTS "${_ocml_bc}")
-	  message(FATAL_ERROR
-	    "AMDDeviceLibs ocml imported target has missing IMPORTED_LOCATION: ${_ocml_bc}")
-	endif()
-	get_filename_component(PROTEUS_ROCM_AMDGCN_BITCODE_DIR "${_ocml_bc}" DIRECTORY)
-	message(STATUS "Found ROCm AMDGCN bitcode dir: ${PROTEUS_ROCM_AMDGCN_BITCODE_DIR}")
+  endif()
 endif()
 
 if(PROTEUS_ENABLE_MPI)

--- a/docs/dev/runtime-hip-toolchain.md
+++ b/docs/dev/runtime-hip-toolchain.md
@@ -1,0 +1,101 @@
+# Runtime HIP Asset Detection
+
+## Overview
+
+Proteus no longer bakes the ROCm device-library directory into `libproteus` at
+CMake configure time.
+
+Instead, HIP builds resolve the ROCm installation from the process environment
+on first use in `src/runtime/Frontend/HIPToolchain.cpp`.
+
+This currently affects the HIP device compilation path in
+`src/include/proteus/impl/Frontend/DispatcherHIP.h`, where Proteus links ROCm
+bitcode such as `ocml.bc`, `ockl.bc`, and the selected `oclc_*` configuration
+modules into the generated LLVM IR before HIPRTC code generation.
+
+## Resolution Order
+
+Proteus looks for a ROCm root in this order:
+
+1. `PROTEUS_ROCM_PATH`
+2. `ROCM_PATH`
+
+If neither is set, runtime HIP compilation fails.
+
+## Resolved Assets
+
+Once a root is found, Proteus derives the ROCm device-library directory from:
+
+1. `amdgcn/bitcode`
+
+under the selected ROCm root.
+
+The existing runtime selection logic for the bitcode files themselves is
+unchanged:
+
+1. `ocml.bc`
+2. `ockl.bc`
+3. the newest available `oclc_abi_version_*.bc`
+4. the device-specific `oclc_isa_version_<arch>.bc`
+5. the default math and wavefront policy bitcode modules
+
+## Version Check
+
+HIP builds embed the build-time `hip_VERSION` as a compile definition.
+
+At runtime, Proteus reads the selected installation version from:
+
+1. `.info/version`
+2. `include/hip/hip_version.h`
+3. `include/hip/amd_detail/amd_hip_version.h`
+
+Proteus compares the major and minor versions between:
+
+1. the HIP installation used to build Proteus
+2. the ROCm root selected at runtime
+
+If either component differs, runtime HIP asset resolution fails.
+
+## Why This Exists
+
+The previous behavior embedded a builder-local ROCm bitcode path into
+`libproteus`. That is fragile for:
+
+1. installed shared libraries moved to another machine
+2. cluster environments where ROCm is injected by environment modules
+3. systems where the runtime ROCm prefix differs from the build machine
+
+Runtime resolution makes HIP asset lookup relocatable, provided the process
+environment points at a compatible ROCm installation.
+
+## Cache Interaction
+
+HIP toolchain resolution happens only when Proteus must compile new HIP code.
+
+If a program hits the object cache, it may succeed without touching the runtime
+resolver at all. This can mask missing `ROCM_PATH`-style environment
+variables.
+
+When debugging, clear the cache first:
+
+```bash
+rm -rf .proteus
+```
+
+Or set an explicit cache location:
+
+```bash
+export PROTEUS_CACHE_DIR=/tmp/proteus-cache
+```
+
+## Typical Cluster Usage
+
+On systems that provide ROCm through environment modules, loading the module is
+usually enough because it exports `ROCM_PATH`:
+
+```bash
+ml load rocm/7.1.1
+```
+
+After that, HIP frontend tests and applications can resolve the runtime ROCm
+device libraries without relying on build-time absolute paths.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,7 @@ nav:
       - Optimization Pipeline: dev/optimization-pipeline.md
     - Python Wheel Build: dev/python-wheel.md
     - Detecting CUDA Toolchain: dev/runtime-cuda-toolchain.md
+    - Detecting HIP Assets: dev/runtime-hip-toolchain.md
     - Creating a PR: dev/pr.md
     - API Reference: dev/api.md
 repo_url: https://github.com/Olympus-HPC/proteus

--- a/src/include/proteus/impl/Frontend/DispatcherHIP.h
+++ b/src/include/proteus/impl/Frontend/DispatcherHIP.h
@@ -7,6 +7,7 @@
 #include "proteus/Frontend/Dispatcher.h"
 #include "proteus/TimeTracing.h"
 #include "proteus/impl/Caching/ObjectCacheChain.h"
+#include "proteus/impl/Frontend/HIPToolchain.h"
 #include "proteus/impl/JitEngineDeviceHIP.h"
 
 #include <llvm/Bitcode/BitcodeReader.h>
@@ -32,30 +33,31 @@ public:
     // trigger a lifetime bug.
     auto CtxOwner = std::move(Ctx);
     auto ModOwner = std::move(Mod);
+    const auto &Toolchain = resolveHIPToolchain();
 
     auto LoadBitcode = [&](const llvm::SmallString<256> &Path) {
       auto BufferOrErr = llvm::MemoryBuffer::getFile(Path);
       if (!BufferOrErr || !BufferOrErr.get())
         reportFatalError("DispatchHIP: failed to read ROCm bitcode file: " +
-                         Path.str().str());
+                         Path.str().str() + " (" + Toolchain.Origin + ")");
       auto Parsed = llvm::parseBitcodeFile(
           BufferOrErr->get()->getMemBufferRef(), ModOwner->getContext());
       if (!Parsed)
         reportFatalError("DispatchHIP: failed to parse ROCm bitcode file: " +
-                         Path.str().str());
+                         Path.str().str() + " (" + Toolchain.Origin + ")");
       return std::move(Parsed.get());
     };
 
     auto AppendBitcodePath =
         [&](llvm::SmallVectorImpl<llvm::SmallString<256>> &Paths,
             llvm::StringRef Filename) {
-          llvm::SmallString<256> Path{PROTEUS_ROCM_BITCODE_DIR};
+          llvm::SmallString<256> Path{Toolchain.DeviceLibDir};
           llvm::sys::path::append(Path, Filename);
           Paths.push_back(std::move(Path));
         };
 
     auto Exists = [&](llvm::StringRef Filename) -> bool {
-      llvm::SmallString<256> Path{PROTEUS_ROCM_BITCODE_DIR};
+      llvm::SmallString<256> Path{Toolchain.DeviceLibDir};
       llvm::sys::path::append(Path, Filename);
       return llvm::sys::fs::exists(Path);
     };
@@ -85,8 +87,8 @@ public:
     } else {
       reportFatalError(
           std::string("DispatchHIP: missing oclc ABI bitcode under ") +
-          PROTEUS_ROCM_BITCODE_DIR +
-          " (expected oclc_abi_version_{600,500,400}.bc)");
+          Toolchain.DeviceLibDir + " (" + Toolchain.Origin +
+          "; expected oclc_abi_version_{600,500,400}.bc)");
     }
 
     // ISA: derived from device arch like "gfx90a" -> "90a".
@@ -98,8 +100,8 @@ public:
     const std::string IsaFile = ("oclc_isa_version_" + IsaSuffix + ".bc").str();
     if (!Exists(IsaFile))
       reportFatalError(std::string("DispatchHIP: missing ISA bitcode file ") +
-                       IsaFile + " under " + PROTEUS_ROCM_BITCODE_DIR +
-                       " (DeviceArch=" + DeviceArch + ")");
+                       IsaFile + " under " + Toolchain.DeviceLibDir + " (" +
+                       Toolchain.Origin + "; DeviceArch=" + DeviceArch + ")");
     AppendBitcodePath(LibsToLink, IsaFile);
 
     // Math/FP mode defaults (safe defaults, can be revisited later).

--- a/src/include/proteus/impl/Frontend/HIPToolchain.h
+++ b/src/include/proteus/impl/Frontend/HIPToolchain.h
@@ -1,0 +1,19 @@
+#ifndef PROTEUS_RUNTIME_FRONTEND_HIPTOOLCHAIN_H
+#define PROTEUS_RUNTIME_FRONTEND_HIPTOOLCHAIN_H
+
+#include <string>
+
+namespace proteus {
+
+struct ResolvedHIPToolchain {
+  std::string RocmRoot;
+  std::string DeviceLibDir;
+  std::string RuntimeVersion;
+  std::string Origin;
+};
+
+const ResolvedHIPToolchain &resolveHIPToolchain();
+
+} // namespace proteus
+
+#endif

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -12,6 +12,7 @@ set(SOURCES
   Frontend/CppJitCompiler.cpp
   Frontend/CppJitCompilerClang.cpp
   Frontend/CUDAToolchain.cpp
+  Frontend/HIPToolchain.cpp
   Frontend/JitFuncAttribute.cpp
   Frontend/CppJitModule.cpp
   Frontend/LLVMIRJitModule.cpp
@@ -86,7 +87,7 @@ if(PROTEUS_ENABLE_HIP)
   target_compile_definitions(proteus PUBLIC PROTEUS_ENABLE_HIP)
   target_compile_definitions(proteusCore INTERFACE PROTEUS_ENABLE_HIP)
   target_compile_definitions(
-    proteus PRIVATE PROTEUS_ROCM_BITCODE_DIR="${PROTEUS_ROCM_AMDGCN_BITCODE_DIR}")
+    proteus PRIVATE PROTEUS_HIP_VERSION="${hip_VERSION}")
 elseif(PROTEUS_ENABLE_CUDA)
   target_compile_definitions(proteus PUBLIC PROTEUS_ENABLE_CUDA)
   target_compile_definitions(

--- a/src/runtime/Frontend/HIPToolchain.cpp
+++ b/src/runtime/Frontend/HIPToolchain.cpp
@@ -1,0 +1,264 @@
+#include "proteus/impl/Frontend/HIPToolchain.h"
+
+#include "proteus/Error.h"
+
+#if PROTEUS_ENABLE_HIP
+
+#include "proteus/impl/Config.h"
+
+#include <llvm/Support/FileSystem.h>
+#include <llvm/Support/MemoryBuffer.h>
+#include <llvm/Support/Path.h>
+
+#include <cctype>
+#include <mutex>
+#include <optional>
+#include <utility>
+
+namespace proteus {
+
+namespace {
+
+std::optional<std::string> getNonEmptyEnvVar(llvm::StringRef VarName) {
+  std::string Name = VarName.str();
+  auto Value = getEnvOrDefaultString(Name.c_str());
+  if (!Value || Value->empty())
+    return std::nullopt;
+  return Value;
+}
+
+std::string canonicalizeExistingPath(llvm::StringRef Path) {
+  llvm::SmallString<256> RealPath;
+  if (!llvm::sys::fs::real_path(Path, RealPath))
+    return RealPath.str().str();
+  return Path.str();
+}
+
+std::string requireExistingDirectory(llvm::StringRef Path,
+                                     llvm::StringRef Context) {
+  if (!llvm::sys::fs::is_directory(Path))
+    reportFatalError(Context.str() + ": expected directory, got " + Path.str());
+  return canonicalizeExistingPath(Path);
+}
+
+std::string readTextFile(llvm::StringRef Path, llvm::StringRef Context) {
+  auto BufferOrErr = llvm::MemoryBuffer::getFile(Path);
+  if (!BufferOrErr || !BufferOrErr.get())
+    reportFatalError(Context.str() + ": failed to read " + Path.str());
+  return std::string(BufferOrErr.get()->getBuffer());
+}
+
+std::optional<std::pair<std::string, std::string>>
+resolveRootFromEnv(llvm::StringRef VarName) {
+  auto Value = getNonEmptyEnvVar(VarName);
+  if (!Value)
+    return std::nullopt;
+
+  return std::pair<std::string, std::string>{
+      requireExistingDirectory(*Value, VarName), VarName.str() + "=" + *Value};
+}
+
+std::string resolveDeviceLibDirFromRoot(llvm::StringRef Root) {
+  llvm::SmallString<256> Candidate(Root);
+  llvm::sys::path::append(Candidate, "amdgcn", "bitcode");
+  return requireExistingDirectory(Candidate, "ROCm device library directory");
+}
+
+std::optional<std::string> extractVersionPrefix(llvm::StringRef Text) {
+  std::size_t Cursor = 0;
+  while (Cursor < Text.size() &&
+         !std::isdigit(static_cast<unsigned char>(Text[Cursor]))) {
+    ++Cursor;
+  }
+
+  if (Cursor == Text.size())
+    return std::nullopt;
+
+  std::size_t End = Cursor;
+  while (End < Text.size() &&
+         (std::isdigit(static_cast<unsigned char>(Text[End])) ||
+          Text[End] == '.')) {
+    ++End;
+  }
+
+  if (End == Cursor)
+    return std::nullopt;
+  return Text.substr(Cursor, End - Cursor).str();
+}
+
+std::optional<std::string> parseMacroValue(llvm::StringRef Text,
+                                           llvm::StringRef MacroName) {
+  while (!Text.empty()) {
+    std::size_t LineEnd = Text.find_first_of("\r\n");
+    llvm::StringRef Line = Text.substr(0, LineEnd);
+    if (LineEnd == llvm::StringRef::npos) {
+      Text = llvm::StringRef{};
+    } else {
+      Text = Text.substr(LineEnd);
+      while (!Text.empty() && (Text.front() == '\n' || Text.front() == '\r'))
+        Text = Text.drop_front();
+    }
+
+    Line = Line.trim();
+    if (!Line.consume_front("#define"))
+      continue;
+
+    Line = Line.ltrim();
+    if (!Line.consume_front(MacroName))
+      continue;
+    if (!Line.empty() &&
+        !std::isspace(static_cast<unsigned char>(Line.front())))
+      continue;
+
+    Line = Line.ltrim();
+    std::size_t End = 0;
+    while (End < Line.size() &&
+           std::isdigit(static_cast<unsigned char>(Line[End]))) {
+      ++End;
+    }
+    if (End == 0)
+      continue;
+    return Line.substr(0, End).str();
+  }
+
+  return std::nullopt;
+}
+
+std::string readHIPVersionFromHeader(llvm::StringRef Path) {
+  std::string Text = readTextFile(Path, "HIP version header");
+  auto Major = parseMacroValue(Text, "HIP_VERSION_MAJOR");
+  auto Minor = parseMacroValue(Text, "HIP_VERSION_MINOR");
+  if (!Major || !Minor) {
+    reportFatalError("HIP version header: missing HIP_VERSION_MAJOR or "
+                     "HIP_VERSION_MINOR in " +
+                     Path.str());
+  }
+
+  auto Patch = parseMacroValue(Text, "HIP_VERSION_PATCH");
+  if (Patch)
+    return *Major + "." + *Minor + "." + *Patch;
+  return *Major + "." + *Minor;
+}
+
+std::string readHIPVersionFromRoot(llvm::StringRef Root) {
+  llvm::SmallString<256> VersionFile(Root);
+  llvm::sys::path::append(VersionFile, ".info", "version");
+  if (llvm::sys::fs::is_regular_file(VersionFile)) {
+    std::string Text = readTextFile(VersionFile, "ROCm version file");
+    if (auto Version = extractVersionPrefix(Text))
+      return *Version;
+    reportFatalError("ROCm version file: could not parse version from " +
+                     VersionFile.str().str());
+  }
+
+  for (llvm::StringRef RelativePath :
+       {"include/hip/hip_version.h",
+        "include/hip/amd_detail/amd_hip_version.h"}) {
+    llvm::SmallString<256> HeaderPath(Root);
+    llvm::sys::path::append(HeaderPath, RelativePath);
+    if (llvm::sys::fs::is_regular_file(HeaderPath))
+      return readHIPVersionFromHeader(HeaderPath);
+  }
+
+  reportFatalError("Could not locate HIP/ROCm version metadata under " +
+                   Root.str() +
+                   ". Expected .info/version or a HIP version header.");
+}
+
+std::pair<std::string, std::string>
+extractMajorMinorVersion(llvm::StringRef Version, llvm::StringRef Context) {
+  auto ParseComponent = [&](std::size_t Start) -> std::optional<std::string> {
+    if (Start >= Version.size())
+      return std::nullopt;
+
+    std::size_t End = Start;
+    while (End < Version.size() &&
+           std::isdigit(static_cast<unsigned char>(Version[End]))) {
+      ++End;
+    }
+    if (End == Start)
+      return std::nullopt;
+    return Version.substr(Start, End - Start).str();
+  };
+
+  auto Major = ParseComponent(0);
+  if (!Major)
+    reportFatalError(Context.str() + ": could not parse major version from " +
+                     Version.str());
+
+  std::size_t MinorStart = Major->size();
+  if (MinorStart >= Version.size() || Version[MinorStart] != '.')
+    reportFatalError(Context.str() + ": could not parse minor version from " +
+                     Version.str());
+  ++MinorStart;
+
+  auto Minor = ParseComponent(MinorStart);
+  if (!Minor)
+    reportFatalError(Context.str() + ": could not parse minor version from " +
+                     Version.str());
+
+  return {*Major, *Minor};
+}
+
+void validateHIPVersion(llvm::StringRef Root, llvm::StringRef Origin,
+                        llvm::StringRef RuntimeVersion) {
+  constexpr llvm::StringRef BuildHIPVersion = PROTEUS_HIP_VERSION;
+  auto [BuildMajor, BuildMinor] =
+      extractMajorMinorVersion(BuildHIPVersion, "Build HIP version");
+  auto [RuntimeMajor, RuntimeMinor] =
+      extractMajorMinorVersion(RuntimeVersion, "Runtime HIP version");
+  if (BuildMajor != RuntimeMajor || BuildMinor != RuntimeMinor) {
+    reportFatalError(
+        "HIP version mismatch: build used " + BuildHIPVersion.str() + ", but " +
+        Origin.str() + " resolved to HIP version " + RuntimeVersion.str() +
+        " at " + Root.str() + ". Expected matching major and minor versions.");
+  }
+}
+
+ResolvedHIPToolchain resolveHIPToolchainImpl() {
+  std::optional<std::pair<std::string, std::string>> Root;
+  for (llvm::StringRef Var : {"PROTEUS_ROCM_PATH", "ROCM_PATH"}) {
+    Root = resolveRootFromEnv(Var);
+    if (Root)
+      break;
+  }
+
+  if (!Root) {
+    reportFatalError("Failed to resolve the ROCm installation root. Set "
+                     "PROTEUS_ROCM_PATH or ROCM_PATH.");
+  }
+
+  std::string RuntimeVersion = readHIPVersionFromRoot(Root->first);
+  validateHIPVersion(Root->first, Root->second, RuntimeVersion);
+
+  return {Root->first, resolveDeviceLibDirFromRoot(Root->first),
+          std::move(RuntimeVersion), Root->second};
+}
+
+} // namespace
+
+const ResolvedHIPToolchain &resolveHIPToolchain() {
+  static std::once_flag CacheOnce;
+  static std::optional<ResolvedHIPToolchain> Cache;
+
+  std::call_once(CacheOnce, []() { Cache = resolveHIPToolchainImpl(); });
+  return *Cache;
+}
+
+} // namespace proteus
+
+#endif
+
+#if !PROTEUS_ENABLE_HIP
+
+namespace proteus {
+
+const ResolvedHIPToolchain &resolveHIPToolchain() {
+  reportFatalError("HIP toolchain requested in a non-HIP build");
+  static const ResolvedHIPToolchain Unreachable{};
+  return Unreachable;
+}
+
+} // namespace proteus
+
+#endif


### PR DESCRIPTION
- Add a cached HIP toolchain resolver using PROTEUS_ROCM_PATH or ROCM_PATH
- Derive the ROCm amdgcn/bitcode directory at runtime
- Validate runtime HIP major/minor version against the build HIP version
- Switch DispatcherHIP to load ROCm bitcode through the runtime resolver
- Remove configure-time AMDDeviceLibs bitcode path embedding
- Add docs on HIP runtime asset detection