### PR TITLE
Load ROCm HIP libraries at runtime

### DIFF
--- a/src/include/proteus/impl/CoreDeviceHIP.h
+++ b/src/include/proteus/impl/CoreDeviceHIP.h
@@ -22,7 +22,8 @@ using namespace llvm;
 
 inline void *resolveDeviceGlobalAddr(const void *Addr) {
   void *DevPtr = nullptr;
-  proteusHipErrCheck(hipGetSymbolAddress(&DevPtr, HIP_SYMBOL(Addr)));
+  proteusHipErrCheck(
+      proteus::hipdyn::getSymbolAddress(&DevPtr, HIP_SYMBOL(Addr)));
   assert(DevPtr && "Expected non-null device pointer for global");
 
   return DevPtr;
@@ -31,8 +32,8 @@ inline void *resolveDeviceGlobalAddr(const void *Addr) {
 inline hipError_t launchKernelDirect(void *KernelFunc, dim3 GridDim,
                                      dim3 BlockDim, void **KernelArgs,
                                      uint64_t ShmemSize, hipStream_t Stream) {
-  return hipLaunchKernel(KernelFunc, GridDim, BlockDim, KernelArgs, ShmemSize,
-                         Stream);
+  return proteus::hipdyn::launchKernel(KernelFunc, GridDim, BlockDim,
+                                       KernelArgs, ShmemSize, Stream);
 }
 
 inline hipFunction_t getKernelFunctionFromImage(
@@ -41,7 +42,7 @@ inline hipFunction_t getKernelFunctionFromImage(
   hipModule_t HipModule;
   hipFunction_t KernelFunc;
 
-  proteusHipErrCheck(hipModuleLoadData(&HipModule, Image));
+  proteusHipErrCheck(proteus::hipdyn::moduleLoadData(&HipModule, Image));
   if (RelinkGlobalsByCopy) {
     for (auto &[GlobalName, GVI] : VarNameToGlobalInfo) {
       if (!GVI.DevAddr)
@@ -50,15 +51,15 @@ inline hipFunction_t getKernelFunctionFromImage(
 
       hipDeviceptr_t Dptr;
       size_t Bytes;
-      proteusHipErrCheck(hipModuleGetGlobal(&Dptr, &Bytes, HipModule,
-                                            (GlobalName + "$ptr").c_str()));
+      proteusHipErrCheck(proteus::hipdyn::moduleGetGlobal(
+          &Dptr, &Bytes, HipModule, (GlobalName + "$ptr").c_str()));
 
       uint64_t PtrVal = (uint64_t)GVI.DevAddr;
-      proteusHipErrCheck(hipMemcpyHtoD(Dptr, &PtrVal, Bytes));
+      proteusHipErrCheck(proteus::hipdyn::memcpyHtoD(Dptr, &PtrVal, Bytes));
     }
   }
-  proteusHipErrCheck(
-      hipModuleGetFunction(&KernelFunc, HipModule, KernelName.str().c_str()));
+  proteusHipErrCheck(proteus::hipdyn::moduleGetFunction(
+      &KernelFunc, HipModule, KernelName.str().c_str()));
 
   return KernelFunc;
 }
@@ -66,9 +67,9 @@ inline hipFunction_t getKernelFunctionFromImage(
 inline hipError_t launchKernelFunction(hipFunction_t KernelFunc, dim3 GridDim,
                                        dim3 BlockDim, void **KernelArgs,
                                        uint64_t ShmemSize, hipStream_t Stream) {
-  return hipModuleLaunchKernel(KernelFunc, GridDim.x, GridDim.y, GridDim.z,
-                               BlockDim.x, BlockDim.y, BlockDim.z, ShmemSize,
-                               Stream, KernelArgs, nullptr);
+  return proteus::hipdyn::moduleLaunchKernel(
+      KernelFunc, GridDim.x, GridDim.y, GridDim.z, BlockDim.x, BlockDim.y,
+      BlockDim.z, ShmemSize, Stream, KernelArgs, nullptr);
 }
 
 } // namespace proteus

--- a/src/include/proteus/impl/CoreLLVMHIP.h
+++ b/src/include/proteus/impl/CoreLLVMHIP.h
@@ -406,18 +406,18 @@ inline std::unique_ptr<MemoryBuffer> codegenRTC(Module &M,
       HIPRTC_JIT_IR_TO_ISA_OPT_EXT, HIPRTC_JIT_IR_TO_ISA_OPT_COUNT_EXT};
   size_t OptArgsSize = 1;
   const void *JITOptionsValues[] = {(void *)OptArgs, (void *)(OptArgsSize)};
-  proteusHiprtcErrCheck(hiprtcLinkCreate(JITOptions.size(), JITOptions.data(),
-                                         (void **)JITOptionsValues,
-                                         &HipLinkStatePtr));
+  proteusHiprtcErrCheck(proteus::hipdyn::rtcLinkCreate(
+      JITOptions.size(), JITOptions.data(), (void **)JITOptionsValues,
+      &HipLinkStatePtr));
   // NOTE: the following version of te code does not set options.
   // proteusHiprtcErrCheck(hiprtcLinkCreate(0, nullptr, nullptr,
   // &hip_link_state_ptr));
 
-  proteusHiprtcErrCheck(hiprtcLinkAddData(
+  proteusHiprtcErrCheck(proteus::hipdyn::rtcLinkAddData(
       HipLinkStatePtr, HIPRTC_JIT_INPUT_LLVM_BITCODE, (void *)ModuleBuf.data(),
       ModuleBuf.size(), "", 0, nullptr, nullptr));
-  proteusHiprtcErrCheck(
-      hiprtcLinkComplete(HipLinkStatePtr, (void **)&BinOut, &BinSize));
+  proteusHiprtcErrCheck(proteus::hipdyn::rtcLinkComplete(
+      HipLinkStatePtr, (void **)&BinOut, &BinSize));
 
   return MemoryBuffer::getMemBuffer(StringRef{BinOut, BinSize});
 }

--- a/src/include/proteus/impl/HIPRuntimeAPI.h
+++ b/src/include/proteus/impl/HIPRuntimeAPI.h
@@ -1,0 +1,44 @@
+#ifndef PROTEUS_HIP_RUNTIME_API_H
+#define PROTEUS_HIP_RUNTIME_API_H
+
+#include <hip/hip_runtime.h>
+#include <hip/hip_runtime_api.h>
+#include <hip/hiprtc.h>
+
+namespace proteus::hipdyn {
+
+const char *getErrorString(hipError_t Error);
+hipError_t getDeviceProperties(hipDeviceProp_t *Prop, int DeviceId);
+hipError_t getSymbolAddress(void **DevPtr, const void *Symbol);
+hipError_t memcpyHtoD(hipDeviceptr_t Dst, const void *Src, size_t SizeBytes);
+hipError_t moduleLoadData(hipModule_t *Module, const void *Image);
+hipError_t moduleGetGlobal(hipDeviceptr_t *Dptr, size_t *Bytes,
+                           hipModule_t Module, const char *Name);
+hipError_t moduleGetFunction(hipFunction_t *Function, hipModule_t Module,
+                             const char *Name);
+hipError_t moduleLaunchKernel(hipFunction_t Function, unsigned int GridDimX,
+                              unsigned int GridDimY, unsigned int GridDimZ,
+                              unsigned int BlockDimX, unsigned int BlockDimY,
+                              unsigned int BlockDimZ,
+                              unsigned int SharedMemBytes, hipStream_t Stream,
+                              void **KernelParams, void **Extra);
+hipError_t launchKernel(const void *FunctionAddress, dim3 NumBlocks,
+                        dim3 DimBlocks, void **Args, size_t SharedMemBytes,
+                        hipStream_t Stream);
+hipError_t funcSetAttribute(const void *Function, hipFuncAttribute Attribute,
+                            int Value);
+
+const char *getRTCErrorString(hiprtcResult Result);
+hiprtcResult rtcLinkCreate(unsigned int NumOptions, hiprtcJIT_option *Options,
+                           void **OptionValues, hiprtcLinkState *LinkStateOut);
+hiprtcResult rtcLinkAddData(hiprtcLinkState LinkState,
+                            hiprtcJITInputType InputType, void *Image,
+                            size_t ImageSize, const char *Name,
+                            unsigned int NumOptions, hiprtcJIT_option *Options,
+                            void **OptionValues);
+hiprtcResult rtcLinkComplete(hiprtcLinkState LinkState, void **BinOut,
+                             size_t *SizeOut);
+
+} // namespace proteus::hipdyn
+
+#endif

--- a/src/include/proteus/impl/JitEngineDeviceHIP.h
+++ b/src/include/proteus/impl/JitEngineDeviceHIP.h
@@ -13,6 +13,7 @@
 
 #include "proteus/impl/JitEngineDevice.h"
 #include "proteus/impl/Utils.h"
+#include "proteus/impl/UtilsHIP.h"
 
 namespace proteus {
 

--- a/src/include/proteus/impl/UtilsHIP.h
+++ b/src/include/proteus/impl/UtilsHIP.h
@@ -11,6 +11,8 @@
 #ifndef PROTEUS_UTILS_HIP_H
 #define PROTEUS_UTILS_HIP_H
 
+#include "proteus/impl/HIPRuntimeAPI.h"
+
 #include <hip/hip_runtime.h>
 #include <hip/hip_runtime_api.h>
 #include <hip/hiprtc.h>
@@ -20,7 +22,7 @@
     hipError_t err = CALL;                                                     \
     if (err != hipSuccess) {                                                   \
       printf("ERROR @ %s:%d ->  %s\n", __FILE__, __LINE__,                     \
-             hipGetErrorString(err));                                          \
+             proteus::hipdyn::getErrorString(err));                            \
       abort();                                                                 \
     }                                                                          \
   }
@@ -30,7 +32,7 @@
     hiprtcResult err = CALL;                                                   \
     if (err != HIPRTC_SUCCESS) {                                               \
       printf("ERROR @ %s:%d ->  %s\n", __FILE__, __LINE__,                     \
-             hiprtcGetErrorString(err));                                       \
+             proteus::hipdyn::getRTCErrorString(err));                         \
       abort();                                                                 \
     }                                                                          \
   }

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -43,6 +43,7 @@ endif()
 
 if(PROTEUS_ENABLE_HIP)
   list(APPEND SOURCES
+    HIPRuntimeAPI.cpp
     CompilerInterfaceDevice.cpp
     JitEngineDeviceHIP.cpp
   )
@@ -217,8 +218,22 @@ endif()
 
 if(PROTEUS_ENABLE_HIP)
   target_include_directories(proteus SYSTEM PRIVATE ${hip_INCLUDE_DIRS})
-  target_link_libraries(proteus PRIVATE hip::host hiprtc::hiprtc)
   target_include_directories(proteusCore SYSTEM INTERFACE ${hip_INCLUDE_DIRS})
+  target_compile_definitions(
+    proteus PRIVATE
+    $<TARGET_PROPERTY:hip::host,INTERFACE_COMPILE_DEFINITIONS>)
+  target_compile_options(
+    proteus PRIVATE
+    $<TARGET_PROPERTY:hip::host,INTERFACE_COMPILE_OPTIONS>)
+  target_compile_definitions(
+    proteusCore INTERFACE
+    $<TARGET_PROPERTY:hip::host,INTERFACE_COMPILE_DEFINITIONS>)
+  target_compile_options(
+    proteusCore INTERFACE
+    $<TARGET_PROPERTY:hip::host,INTERFACE_COMPILE_OPTIONS>)
+  if(UNIX)
+    target_link_libraries(proteus PRIVATE ${CMAKE_DL_LIBS})
+  endif()
 
   # NOTE: HIP compilation (-x hip) is needed to include the HIP_SYMBOL macro,
   # which depends on the target architecture AMD or NVIDIA.  We define this

--- a/src/runtime/CMakeLists.txt
+++ b/src/runtime/CMakeLists.txt
@@ -92,8 +92,16 @@ endif()
 if(PROTEUS_ENABLE_HIP)
   target_compile_definitions(proteus PUBLIC PROTEUS_ENABLE_HIP)
   target_compile_definitions(proteusCore INTERFACE PROTEUS_ENABLE_HIP)
+  string(REGEX MATCH "^[0-9]+" PROTEUS_HIP_VERSION_MAJOR "${hip_VERSION}")
+  string(REGEX MATCH "^[0-9]+" PROTEUS_HIPRTC_VERSION_MAJOR "${hiprtc_VERSION}")
+  get_filename_component(PROTEUS_HIP_INSTALL_ROOT
+    "${hip_DIR}/../../.." REALPATH)
   target_compile_definitions(
-    proteus PRIVATE PROTEUS_HIP_VERSION="${hip_VERSION}")
+    proteus PRIVATE
+    PROTEUS_HIP_VERSION="${hip_VERSION}"
+    PROTEUS_HIP_INSTALL_ROOT="${PROTEUS_HIP_INSTALL_ROOT}"
+    PROTEUS_HIP_RUNTIME_LIBRARY_SONAME="libamdhip64.so.${PROTEUS_HIP_VERSION_MAJOR}"
+    PROTEUS_HIPRTC_LIBRARY_SONAME="libhiprtc.so.${PROTEUS_HIPRTC_VERSION_MAJOR}")
 elseif(PROTEUS_ENABLE_CUDA)
   target_compile_definitions(proteus PUBLIC PROTEUS_ENABLE_CUDA)
   target_compile_definitions(

--- a/src/runtime/Frontend/HIPToolchain.cpp
+++ b/src/runtime/Frontend/HIPToolchain.cpp
@@ -15,6 +15,10 @@
 #include <optional>
 #include <utility>
 
+#ifndef PROTEUS_HIP_INSTALL_ROOT
+#define PROTEUS_HIP_INSTALL_ROOT ""
+#endif
+
 namespace proteus {
 
 namespace {
@@ -56,6 +60,17 @@ resolveRootFromEnv(llvm::StringRef VarName) {
 
   return std::pair<std::string, std::string>{
       requireExistingDirectory(*Value, VarName), VarName.str() + "=" + *Value};
+}
+
+std::optional<std::pair<std::string, std::string>> resolveRootFromBuild() {
+  if (llvm::StringRef(PROTEUS_HIP_INSTALL_ROOT).empty())
+    return std::nullopt;
+
+  return std::pair<std::string, std::string>{
+      requireExistingDirectory(PROTEUS_HIP_INSTALL_ROOT,
+                               "Build-time ROCm installation root"),
+      "build-time ROCm installation root " +
+          std::string(PROTEUS_HIP_INSTALL_ROOT)};
 }
 
 std::string resolveDeviceLibDirFromRoot(llvm::StringRef Root) {
@@ -222,6 +237,8 @@ ResolvedHIPToolchain resolveHIPToolchainImpl() {
     if (Root)
       break;
   }
+  if (!Root)
+    Root = resolveRootFromBuild();
 
   if (!Root) {
     reportFatalError("Failed to resolve the ROCm installation root. Set "

--- a/src/runtime/Frontend/JitFuncAttribute.cpp
+++ b/src/runtime/Frontend/JitFuncAttribute.cpp
@@ -35,7 +35,7 @@ void setFuncAttribute(TargetModelType TargetModel, void *KernelFunc,
   case TargetModelType::HIP:
     switch (Attr) {
     case JitFuncAttribute::MaxDynamicSharedMemorySize:
-      proteusHipErrCheck(hipFuncSetAttribute(
+      proteusHipErrCheck(proteus::hipdyn::funcSetAttribute(
           reinterpret_cast<hipFunction_t>(KernelFunc),
           hipFuncAttributeMaxDynamicSharedMemorySize, Value));
       return;

--- a/src/runtime/HIPRuntimeAPI.cpp
+++ b/src/runtime/HIPRuntimeAPI.cpp
@@ -7,10 +7,38 @@
 #include <mutex>
 #include <string>
 
+#ifndef PROTEUS_HIP_RUNTIME_LIBRARY_SONAME
+#define PROTEUS_HIP_RUNTIME_LIBRARY_SONAME "libamdhip64.so"
+#endif
+
+#ifndef PROTEUS_HIPRTC_LIBRARY_SONAME
+#define PROTEUS_HIPRTC_LIBRARY_SONAME "libhiprtc.so"
+#endif
+
+#ifndef PROTEUS_HIP_INSTALL_ROOT
+#define PROTEUS_HIP_INSTALL_ROOT ""
+#endif
+
+#define PROTEUS_STRINGIFY_IMPL(X) #X
+#define PROTEUS_STRINGIFY(X) PROTEUS_STRINGIFY_IMPL(X)
+
 namespace {
 
 void *loadLibrary(const char *PrimaryName, const char *FallbackName,
                   const char *Description) {
+  std::string BuildRoot = PROTEUS_HIP_INSTALL_ROOT;
+  if (!BuildRoot.empty()) {
+    std::string PrimaryPath = BuildRoot + "/lib/" + PrimaryName;
+    dlerror();
+    if (void *Handle = dlopen(PrimaryPath.c_str(), RTLD_NOW | RTLD_LOCAL))
+      return Handle;
+
+    std::string FallbackPath = BuildRoot + "/lib/" + FallbackName;
+    dlerror();
+    if (void *Handle = dlopen(FallbackPath.c_str(), RTLD_NOW | RTLD_LOCAL))
+      return Handle;
+  }
+
   dlerror();
   if (void *Handle = dlopen(PrimaryName, RTLD_NOW | RTLD_LOCAL))
     return Handle;
@@ -40,7 +68,7 @@ void *getHIPRuntimeHandle() {
   static void *Handle = nullptr;
   static std::once_flag Once;
   std::call_once(Once, []() {
-    Handle = loadLibrary("libamdhip64.so.7", "libamdhip64.so",
+    Handle = loadLibrary(PROTEUS_HIP_RUNTIME_LIBRARY_SONAME, "libamdhip64.so",
                          "the ROCm HIP runtime library");
   });
   return Handle;
@@ -50,7 +78,7 @@ void *getHIPRTCHandle() {
   static void *Handle = nullptr;
   static std::once_flag Once;
   std::call_once(Once, []() {
-    Handle = loadLibrary("libhiprtc.so.7", "libhiprtc.so",
+    Handle = loadLibrary(PROTEUS_HIPRTC_LIBRARY_SONAME, "libhiprtc.so",
                          "the ROCm HIPRTC library");
   });
   return Handle;
@@ -88,7 +116,8 @@ const char *getErrorString(hipError_t Error) {
 
 hipError_t getDeviceProperties(hipDeviceProp_t *Prop, int DeviceId) {
   using Fn = decltype(&::hipGetDeviceProperties);
-  static Fn Func = resolveHIPRuntimeSymbol<Fn>("hipGetDeviceProperties");
+  static Fn Func =
+      resolveHIPRuntimeSymbol<Fn>(PROTEUS_STRINGIFY(hipGetDeviceProperties));
   return Func(Prop, DeviceId);
 }
 
@@ -101,7 +130,7 @@ hipError_t getSymbolAddress(void **DevPtr, const void *Symbol) {
 hipError_t memcpyHtoD(hipDeviceptr_t Dst, const void *Src, size_t SizeBytes) {
   using Fn = decltype(&::hipMemcpyHtoD);
   static Fn Func = resolveHIPRuntimeSymbol<Fn>("hipMemcpyHtoD");
-  return Func(Dst, Src, SizeBytes);
+  return Func(Dst, const_cast<void *>(Src), SizeBytes);
 }
 
 hipError_t moduleLoadData(hipModule_t *Module, const void *Image) {

--- a/src/runtime/HIPRuntimeAPI.cpp
+++ b/src/runtime/HIPRuntimeAPI.cpp
@@ -1,0 +1,187 @@
+#include "proteus/impl/HIPRuntimeAPI.h"
+
+#include "proteus/Error.h"
+
+#include <dlfcn.h>
+
+#include <mutex>
+#include <string>
+
+namespace {
+
+void *loadLibrary(const char *PrimaryName, const char *FallbackName,
+                  const char *Description) {
+  dlerror();
+  if (void *Handle = dlopen(PrimaryName, RTLD_NOW | RTLD_LOCAL))
+    return Handle;
+  const char *PrimaryError = dlerror();
+
+  dlerror();
+  if (void *Handle = dlopen(FallbackName, RTLD_NOW | RTLD_LOCAL))
+    return Handle;
+  const char *FallbackError = dlerror();
+
+  std::string Message =
+      std::string("ROCm functionality requires ") + Description +
+      ", but Proteus could not load " + PrimaryName + " or " + FallbackName +
+      ". Ensure a compatible system ROCm installation is available";
+  if (PrimaryError || FallbackError) {
+    Message += ".";
+    if (PrimaryError)
+      Message += " " + std::string(PrimaryName) + ": " + PrimaryError;
+    if (FallbackError)
+      Message += " " + std::string(FallbackName) + ": " + FallbackError;
+  }
+  Message += " You may need to configure LD_LIBRARY_PATH from ROCM_PATH.";
+  proteus::reportFatalError(Message);
+}
+
+void *getHIPRuntimeHandle() {
+  static void *Handle = nullptr;
+  static std::once_flag Once;
+  std::call_once(Once, []() {
+    Handle = loadLibrary("libamdhip64.so.7", "libamdhip64.so",
+                         "the ROCm HIP runtime library");
+  });
+  return Handle;
+}
+
+void *getHIPRTCHandle() {
+  static void *Handle = nullptr;
+  static std::once_flag Once;
+  std::call_once(Once, []() {
+    Handle = loadLibrary("libhiprtc.so.7", "libhiprtc.so",
+                         "the ROCm HIPRTC library");
+  });
+  return Handle;
+}
+
+template <typename Fn>
+Fn resolveSymbol(void *Handle, const char *Name, const char *LibraryName) {
+  dlerror();
+  void *Symbol = dlsym(Handle, Name);
+  if (const char *Err = dlerror()) {
+    proteus::reportFatalError("Failed to resolve ROCm symbol " +
+                              std::string(Name) + " from " + LibraryName +
+                              ": " + Err);
+  }
+  return reinterpret_cast<Fn>(Symbol);
+}
+
+template <typename Fn> Fn resolveHIPRuntimeSymbol(const char *Name) {
+  return resolveSymbol<Fn>(getHIPRuntimeHandle(), Name, "libamdhip64");
+}
+
+template <typename Fn> Fn resolveHIPRTCSymbol(const char *Name) {
+  return resolveSymbol<Fn>(getHIPRTCHandle(), Name, "libhiprtc");
+}
+
+} // namespace
+
+namespace proteus::hipdyn {
+
+const char *getErrorString(hipError_t Error) {
+  using Fn = decltype(&::hipGetErrorString);
+  static Fn Func = resolveHIPRuntimeSymbol<Fn>("hipGetErrorString");
+  return Func(Error);
+}
+
+hipError_t getDeviceProperties(hipDeviceProp_t *Prop, int DeviceId) {
+  using Fn = decltype(&::hipGetDeviceProperties);
+  static Fn Func = resolveHIPRuntimeSymbol<Fn>("hipGetDeviceProperties");
+  return Func(Prop, DeviceId);
+}
+
+hipError_t getSymbolAddress(void **DevPtr, const void *Symbol) {
+  using Fn = hipError_t (*)(void **, const void *);
+  static Fn Func = resolveHIPRuntimeSymbol<Fn>("hipGetSymbolAddress");
+  return Func(DevPtr, Symbol);
+}
+
+hipError_t memcpyHtoD(hipDeviceptr_t Dst, const void *Src, size_t SizeBytes) {
+  using Fn = decltype(&::hipMemcpyHtoD);
+  static Fn Func = resolveHIPRuntimeSymbol<Fn>("hipMemcpyHtoD");
+  return Func(Dst, Src, SizeBytes);
+}
+
+hipError_t moduleLoadData(hipModule_t *Module, const void *Image) {
+  using Fn = decltype(&::hipModuleLoadData);
+  static Fn Func = resolveHIPRuntimeSymbol<Fn>("hipModuleLoadData");
+  return Func(Module, Image);
+}
+
+hipError_t moduleGetGlobal(hipDeviceptr_t *Dptr, size_t *Bytes,
+                           hipModule_t Module, const char *Name) {
+  using Fn = decltype(&::hipModuleGetGlobal);
+  static Fn Func = resolveHIPRuntimeSymbol<Fn>("hipModuleGetGlobal");
+  return Func(Dptr, Bytes, Module, Name);
+}
+
+hipError_t moduleGetFunction(hipFunction_t *Function, hipModule_t Module,
+                             const char *Name) {
+  using Fn = decltype(&::hipModuleGetFunction);
+  static Fn Func = resolveHIPRuntimeSymbol<Fn>("hipModuleGetFunction");
+  return Func(Function, Module, Name);
+}
+
+hipError_t moduleLaunchKernel(hipFunction_t Function, unsigned int GridDimX,
+                              unsigned int GridDimY, unsigned int GridDimZ,
+                              unsigned int BlockDimX, unsigned int BlockDimY,
+                              unsigned int BlockDimZ,
+                              unsigned int SharedMemBytes, hipStream_t Stream,
+                              void **KernelParams, void **Extra) {
+  using Fn = decltype(&::hipModuleLaunchKernel);
+  static Fn Func = resolveHIPRuntimeSymbol<Fn>("hipModuleLaunchKernel");
+  return Func(Function, GridDimX, GridDimY, GridDimZ, BlockDimX, BlockDimY,
+              BlockDimZ, SharedMemBytes, Stream, KernelParams, Extra);
+}
+
+hipError_t launchKernel(const void *FunctionAddress, dim3 NumBlocks,
+                        dim3 DimBlocks, void **Args, size_t SharedMemBytes,
+                        hipStream_t Stream) {
+  using Fn =
+      hipError_t (*)(const void *, dim3, dim3, void **, size_t, hipStream_t);
+  static Fn Func = resolveHIPRuntimeSymbol<Fn>("hipLaunchKernel");
+  return Func(FunctionAddress, NumBlocks, DimBlocks, Args, SharedMemBytes,
+              Stream);
+}
+
+hipError_t funcSetAttribute(const void *Function, hipFuncAttribute Attribute,
+                            int Value) {
+  using Fn = hipError_t (*)(const void *, hipFuncAttribute, int);
+  static Fn Func = resolveHIPRuntimeSymbol<Fn>("hipFuncSetAttribute");
+  return Func(Function, Attribute, Value);
+}
+
+const char *getRTCErrorString(hiprtcResult Result) {
+  using Fn = decltype(&::hiprtcGetErrorString);
+  static Fn Func = resolveHIPRTCSymbol<Fn>("hiprtcGetErrorString");
+  return Func(Result);
+}
+
+hiprtcResult rtcLinkCreate(unsigned int NumOptions, hiprtcJIT_option *Options,
+                           void **OptionValues, hiprtcLinkState *LinkStateOut) {
+  using Fn = decltype(&::hiprtcLinkCreate);
+  static Fn Func = resolveHIPRTCSymbol<Fn>("hiprtcLinkCreate");
+  return Func(NumOptions, Options, OptionValues, LinkStateOut);
+}
+
+hiprtcResult rtcLinkAddData(hiprtcLinkState LinkState,
+                            hiprtcJITInputType InputType, void *Image,
+                            size_t ImageSize, const char *Name,
+                            unsigned int NumOptions, hiprtcJIT_option *Options,
+                            void **OptionValues) {
+  using Fn = decltype(&::hiprtcLinkAddData);
+  static Fn Func = resolveHIPRTCSymbol<Fn>("hiprtcLinkAddData");
+  return Func(LinkState, InputType, Image, ImageSize, Name, NumOptions, Options,
+              OptionValues);
+}
+
+hiprtcResult rtcLinkComplete(hiprtcLinkState LinkState, void **BinOut,
+                             size_t *SizeOut) {
+  using Fn = decltype(&::hiprtcLinkComplete);
+  static Fn Func = resolveHIPRTCSymbol<Fn>("hiprtcLinkComplete");
+  return Func(LinkState, BinOut, SizeOut);
+}
+
+} // namespace proteus::hipdyn

--- a/src/runtime/JitEngineDeviceHIP.cpp
+++ b/src/runtime/JitEngineDeviceHIP.cpp
@@ -366,7 +366,7 @@ void JitEngineDeviceHIP::extractModules(BinaryInfo &BinInfo) {
 JitEngineDeviceHIP::JitEngineDeviceHIP() {
   TIMESCOPE(JitEngineDeviceHIP, JitEngineDeviceHIP);
   hipDeviceProp_t DevProp;
-  proteusHipErrCheck(hipGetDeviceProperties(&DevProp, 0));
+  proteusHipErrCheck(proteus::hipdyn::getDeviceProperties(&DevProp, 0));
 
   DeviceArch = DevProp.gcnArchName;
   DeviceArch = DeviceArch.substr(0, DeviceArch.find_first_of(":"));


### PR DESCRIPTION
We avoid the dependency at build time to simplify python packaging.