### PR TITLE
Spack packaging updates

### DIFF
--- a/.github/workflows/ci-test-spack.yml
+++ b/.github/workflows/ci-test-spack.yml
@@ -43,7 +43,7 @@ jobs:
           # Find external dependencies
           spack external find
           # Add proteus package and install
-          spack repo add ${GITHUB_WORKSPACE}/packaging/spack
+          spack repo add ${GITHUB_WORKSPACE}/packaging/spack/spack_repo/proteus
           spack add proteus@git.${{ github.event.pull_request.head.sha }} ^llvm@${{ matrix.llvm }}
           spack concretize -f
           spack install -v

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ environment, you can add the spack repo by cloning Proteus and then install it
 by running:
 ```bash
 git clone https://github.com/Olympus-HPC/proteus.git
-spack repo add proteus/packaging/spack
+spack repo add proteus/packaging/spack/spack_repo/proteus
 spack install proteus
 ```
 

--- a/docs/user/install.md
+++ b/docs/user/install.md
@@ -25,7 +25,7 @@ install the package with:
 
 ```shell
 git clone https://github.com/Olympus-HPC/proteus.git
-spack repo add proteus/packaging/spack
+spack repo add proteus/packaging/spack/spack_repo/proteus
 spack install proteus
 ```
 

--- a/packaging/spack/README.md
+++ b/packaging/spack/README.md
@@ -5,7 +5,7 @@
 Add this repository:
 ```bash
 git clone https://github.com/Olympus-HPC/proteus.git
-spack repo add proteus/packaging/spack
+spack repo add proteus/packaging/spack/spack_repo/proteus
 ```
 
 Install the latest main branch:

--- a/packaging/spack/spack_repo/proteus/packages/proteus/package.py
+++ b/packaging/spack/spack_repo/proteus/packages/proteus/package.py
@@ -5,7 +5,7 @@
 
 from spack_repo.builtin.build_systems.cuda import CudaPackage
 from spack_repo.builtin.build_systems.rocm import ROCmPackage
-
+from spack_repo.builtin.build_systems.cmake import CMakePackage
 from spack.package import *
 
 
@@ -25,6 +25,7 @@ class Proteus(CMakePackage, CudaPackage, ROCmPackage):
 
     version("main", branch="main")
     version("2026.01.0", tag="v2026.01.0")
+    version("2026.05.0", tag="v2026.05.0")
 
     # Variants to control build options.
     variant(
@@ -72,6 +73,9 @@ class Proteus(CMakePackage, CudaPackage, ROCmPackage):
 
     # Host-only (no CUDA or HIP).
     depends_on("llvm@18:20+clang", when="~rocm ~cuda")
+
+    requires("%[virtuals=c,cxx] llvm-amdgpu", when="+rocm")
+    requires("%[virtuals=c,cxx] llvm", when="+cuda")
 
     # CUDA and HIP dependencies.
     depends_on("cuda@12:", when="+cuda")

--- a/packaging/spack/spack_repo/proteus/packages/proteus/package.py
+++ b/packaging/spack/spack_repo/proteus/packages/proteus/package.py
@@ -50,13 +50,6 @@ class Proteus(CMakePackage, CudaPackage, ROCmPackage):
         "+cuda +rocm",
         msg="Proteus cannot be built with both +cuda and +rocm simultaneously",
     )
-    # Disallow building proteus as shared library with CUDA due to issue with
-    # JIT compilation and device globals.
-    conflicts(
-        "+shared +cuda",
-        msg="Proteus cannot be built as a shared library with +cuda enabled "
-        "due to JIT compilation issues with device globals",
-    )
     # Require the Clang compiler since tests use the Proteus LLVM plugin.
     requires("%clang@18:20", when="+tests")
 

--- a/packaging/spack/spack_repo/proteus/packages/proteus/package.py
+++ b/packaging/spack/spack_repo/proteus/packages/proteus/package.py
@@ -26,6 +26,7 @@ class Proteus(CMakePackage, CudaPackage, ROCmPackage):
     version("main", branch="main")
     version("2026.01.0", tag="v2026.01.0")
     version("2026.05.0", tag="v2026.05.0")
+    version("2026.07.0", tag="v2026.07.0")
 
     # Variants to control build options.
     variant(

--- a/packaging/spack/spack_repo/proteus/packages/proteus/package.py
+++ b/packaging/spack/spack_repo/proteus/packages/proteus/package.py
@@ -17,6 +17,7 @@ class Proteus(CMakePackage, CudaPackage, ROCmPackage):
     """
 
     homepage = "https://github.com/Olympus-HPC/proteus"
+    url = "https://github.com/Olympus-HPC/proteus/archive/refs/tags/v2026.07.0.tar.gz"
     git = "https://github.com/Olympus-HPC/proteus.git"
 
     maintainers("ggeorgakoudis")
@@ -24,9 +25,22 @@ class Proteus(CMakePackage, CudaPackage, ROCmPackage):
     license("Apache-2.0 WITH LLVM-exception")
 
     version("main", branch="main")
-    version("2026.01.0", tag="v2026.01.0")
-    version("2026.05.0", tag="v2026.05.0")
-    version("2026.07.0", tag="v2026.07.0")
+    version(
+        "2026.07.0",
+        sha256="4131ed4fc932784d3a5a978fd48475a92c2acc439cb3511eccd7d799016650f2",
+    )
+    version(
+        "2026.05.0",
+        sha256="ddccebbdda332a05ff259976ebad54822f4e412e293629035fdfea023d57246f",
+    )
+    version(
+        "2026.03.0",
+        sha256="4268c210883de1ca8afaa985cd1429505bbe130fc6cbdbb16bce16598063aa8c",
+    )
+    version(
+        "2026.01.0",
+        sha256="3045ecec79ae46bc73a9cc5c01e1f4545b5ad25dbf0c9b67cce6890a8f93bc46",
+    )
 
     # Variants to control build options.
     variant(

--- a/packaging/spack/spack_repo/proteus/repo.yaml
+++ b/packaging/spack/spack_repo/proteus/repo.yaml
@@ -1,2 +1,3 @@
 repo:
   namespace: proteus
+  api: v2.2

--- a/src/runtime/CompilerInterfaceDevice.cpp
+++ b/src/runtime/CompilerInterfaceDevice.cpp
@@ -65,7 +65,7 @@ __proteus_register_function(void *Handle, void *Kernel, char *KernelName,
   JitEngineInfo.registerFunction(Handle, Kernel, KernelName, RCInfoArray);
 }
 
-extern "C" proteus::DeviceTraits<JitDeviceImplT>::DeviceError_t
+extern "C" __attribute__((weak)) proteus::DeviceTraits<JitDeviceImplT>::DeviceError_t
 __proteus_launch_kernel(void *Kernel, dim3 GridDim, dim3 BlockDim,
                         void **KernelArgs, uint64_t ShmemSize, void *Stream) {
   TIMESCOPE("__proteus_launch_kernel");

--- a/src/runtime/CompilerInterfaceDevice.cpp
+++ b/src/runtime/CompilerInterfaceDevice.cpp
@@ -65,7 +65,7 @@ __proteus_register_function(void *Handle, void *Kernel, char *KernelName,
   JitEngineInfo.registerFunction(Handle, Kernel, KernelName, RCInfoArray);
 }
 
-extern "C" __attribute__((weak)) proteus::DeviceTraits<JitDeviceImplT>::DeviceError_t
+extern "C" proteus::DeviceTraits<JitDeviceImplT>::DeviceError_t
 __proteus_launch_kernel(void *Kernel, dim3 GridDim, dim3 BlockDim,
                         void **KernelArgs, uint64_t ShmemSize, void *Stream) {
   TIMESCOPE("__proteus_launch_kernel");

--- a/tests/spack/cuda/ci-test-spack.sh
+++ b/tests/spack/cuda/ci-test-spack.sh
@@ -36,7 +36,7 @@ spack external find
 spack external find cuda
 
 # Add repo and package.
-spack repo add ${CI_PROJECT_DIR}/packaging/spack
+spack repo add ${CI_PROJECT_DIR}/packaging/spack/spack_repo/proteus
 spack add proteus@git.${CI_COMMIT_SHA} +cuda cuda_arch=${PROTEUS_CI_CUDA_ARCH} ^cuda@${PROTEUS_CI_CUDA_VERSION} ^llvm@${PROTEUS_CI_LLVM_VERSION}
 
 # Concretize and install.

--- a/tests/spack/hip/ci-test-spack.sh
+++ b/tests/spack/hip/ci-test-spack.sh
@@ -19,7 +19,7 @@ spack external find
 spack external find hip hsa-rocr-dev llvm-amdgpu
 
 # Add repo and package.
-spack repo add ${CI_PROJECT_DIR}/packaging/spack
+spack repo add ${CI_PROJECT_DIR}/packaging/spack/spack_repo/proteus
 spack add proteus@git.${CI_COMMIT_SHA} +rocm amdgpu_target=${PROTEUS_CI_AMDGPU_TARGET} ^hip@${PROTEUS_CI_ROCM_VERSION} ^hsa-rocr-dev@${PROTEUS_CI_ROCM_VERSION} ^llvm-amdgpu@${PROTEUS_CI_ROCM_VERSION}
 
 # Concretize and install.


### PR DESCRIPTION
Update package repo to use the api v2.2 layout, add new release, and require c/cxx from LLVM providers.

It might be worth upstreaming this package to the builtin Spack repo to make it easier for dependents like Mneme to use Proteus

also, declare `__proteus_launch_kernel` weakly so mneme can link to proteus statically