### PR TITLE
Fixup: Set user/dir for CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,10 +30,10 @@ variables:
 ##### LC GITLAB CONFIGURATION
 # Use an LLNL service user to run CI. This prevents from running pipelines as
 # an actual user.
-  LLNL_SERVICE_USER: "proteusdev"
+  LLNL_SERVICE_USER: "fink12"
 # Use the service user workspace. Solves permission issues, stores everything
 # at the same location whoever triggers a pipeline.
-  CUSTOM_CI_BUILDS_DIR: "/usr/workspace/proteusdev/gitlab-runner"
+  CUSTOM_CI_BUILDS_DIR: "/usr/workspace/fink12/gitlab-runner-proteus"
 # Tells Gitlab to recursively update the submodules when cloning the project.
 #  GIT_SUBMODULE_STRATEGY: recursive
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,7 +30,7 @@ variables:
 ##### LC GITLAB CONFIGURATION
 # Use an LLNL service user to run CI. This prevents from running pipelines as
 # an actual user.
-  LLNL_SERVICE_USER: "proteusdev"
+  LLNL_SERVICE_USER: "fink12"
 # Use the service user workspace. Solves permission issues, stores everything
 # at the same location whoever triggers a pipeline.
   CUSTOM_CI_BUILDS_DIR: "/usr/workspace/fink12/gitlab-runner-proteus"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,7 +30,7 @@ variables:
 ##### LC GITLAB CONFIGURATION
 # Use an LLNL service user to run CI. This prevents from running pipelines as
 # an actual user.
-  LLNL_SERVICE_USER: "fink12"
+  LLNL_SERVICE_USER: "proteusdev"
 # Use the service user workspace. Solves permission issues, stores everything
 # at the same location whoever triggers a pipeline.
   CUSTOM_CI_BUILDS_DIR: "/usr/workspace/fink12/gitlab-runner-proteus"

--- a/.gitlab/custom-jobs-and-variables.yml
+++ b/.gitlab/custom-jobs-and-variables.yml
@@ -46,9 +46,9 @@ variables:
 # OPTIONAL: "-o per-resource.count=2" allows to get 2 jobs running on each node.
   TUOLUMNE_SHARED_ALLOC: "OFF"
 # Arguments for job level allocation
-  TUOLUMNE_JOB_ALLOC: "--job-name=${FLUX_JOB_NAME} --queue=pci --time-limit=1h --nodes=1 --begin-time=+5s"
+  TUOLUMNE_JOB_ALLOC: "--job-name=${FLUX_JOB_NAME} -B asccasc --queue=pci --time-limit=1h --nodes=1 --begin-time=+5s"
 # Arguments for performance job allocation (dedicated allocation with no overlapping).
-  TUOLUMNE_PERF_ALLOC: "--queue=pci --exclusive --time-limit=1h --nodes=1 --begin-time=+5s"
+  TUOLUMNE_PERF_ALLOC: "-B asccasc --queue=pci --exclusive --time-limit=1h --nodes=1 --begin-time=+5s"
 # Add variables that should apply to all the jobs on a machine:
 #  TUOLUMNE_MY_VAR: "..."
 

--- a/.gitlab/custom-jobs-and-variables.yml
+++ b/.gitlab/custom-jobs-and-variables.yml
@@ -34,9 +34,9 @@ variables:
 # OPTIONAL: "-o per-resource.count=2" allows to get 2 jobs running on each node.
   TIOGA_SHARED_ALLOC: "OFF"
 # Arguments for job level allocation
-  TIOGA_JOB_ALLOC: "--job-name=${FLUX_JOB_NAME} --queue=pci --time-limit=1h --nodes=1 --begin-time=+5s"
+  TIOGA_JOB_ALLOC: "--job-name=${FLUX_JOB_NAME} -B asccasc --queue=pci --time-limit=1h --nodes=1 --begin-time=+5s"
 # Arguments for performance job allocation (dedicated allocation with no overlapping).
-  TIOGA_PERF_ALLOC: "--queue=pci --exclusive --time-limit=1h --nodes=1 --begin-time=+5s"
+  TIOGA_PERF_ALLOC: "-B asccasc --queue=pci --exclusive --time-limit=1h --nodes=1 --begin-time=+5s"
 # Add variables that should apply to all the jobs on a machine:
 #  TIOGA_MY_VAR: "..."
 


### PR DESCRIPTION
Since Giorgis has left, the CI jobs that run through the `proteusdev` service user no longer work.
While I am in the `proteusdev` LC group, I cannot access the original CI_BUILDS_DIR nor do things involving `proteusdev`. Therefore, CI is currently broken. This will fix it while I figure out how to get `proteusdev` working again