### PR TITLE
Support LLVM 21

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -133,6 +133,7 @@ meta-only:
       - PROTEUS_CI_LLVM_VERSION: "19.1.7"
       - PROTEUS_CI_LLVM_VERSION: "20.1.8"
         PROTEUS_CODECOV_VERSION_SELECTED: "1"
+      - PROTEUS_CI_LLVM_VERSION: "21.1.8"
       - PROTEUS_CI_LLVM_VERSION: "22.1.0"
   trigger:
     include:

--- a/src/include/proteus/impl/Cloning.h
+++ b/src/include/proteus/impl/Cloning.h
@@ -23,7 +23,7 @@ inline std::unique_ptr<Module> cloneKernelFromModule(Module &M, StringRef Name,
   KernelModuleTmp->setDataLayout(M.getDataLayout());
   KernelModuleTmp->setTargetTriple(M.getTargetTriple());
   KernelModuleTmp->setModuleInlineAsm(M.getModuleInlineAsm());
-#if LLVM_VERSION_MAJOR >= 18 && LLVM_VERSION_MAJOR < 22
+#if LLVM_VERSION_MAJOR >= 18 && LLVM_VERSION_MAJOR < 21
   KernelModuleTmp->IsNewDbgInfoFormat = M.IsNewDbgInfoFormat;
 #endif
 
@@ -365,7 +365,7 @@ struct LinkingCloner {
     ModuleOut->setDataLayout(M.getDataLayout());
     ModuleOut->setTargetTriple(M.getTargetTriple());
     ModuleOut->setModuleInlineAsm(M.getModuleInlineAsm());
-#if LLVM_VERSION_MAJOR >= 18 && LLVM_VERSION_MAJOR < 22
+#if LLVM_VERSION_MAJOR >= 18 && LLVM_VERSION_MAJOR < 21
     ModuleOut->IsNewDbgInfoFormat = M.IsNewDbgInfoFormat;
 #endif
 

--- a/src/pass/ProteusPass.cpp
+++ b/src/pass/ProteusPass.cpp
@@ -358,7 +358,7 @@ private:
     LinkedModule->setDataLayout(LTOModule.getDataLayout());
     LinkedModule->setTargetTriple(LTOModule.getTargetTriple());
     LinkedModule->setModuleInlineAsm(LTOModule.getModuleInlineAsm());
-#if LLVM_VERSION_MAJOR >= 18 && LLVM_VERSION_MAJOR < 22
+#if LLVM_VERSION_MAJOR >= 18 && LLVM_VERSION_MAJOR < 21
     LinkedModule->IsNewDbgInfoFormat = LTOModule.IsNewDbgInfoFormat;
 #endif
 

--- a/src/runtime/Frontend/CppJitCompilerClang.cpp
+++ b/src/runtime/Frontend/CppJitCompilerClang.cpp
@@ -221,7 +221,7 @@ private:
     auto Invocation = createCompilerInvocation(Clangxx, ArgStorage,
                                                TempCompiler, "Clang IR build");
 
-#if LLVM_VERSION_MAJOR >= 22
+#if LLVM_VERSION_MAJOR >= 21
     CompilerInstance Compiler(Invocation);
 #else
     CompilerInstance Compiler;

--- a/src/runtime/Frontend/LLVMCodeBuilder.cpp
+++ b/src/runtime/Frontend/LLVMCodeBuilder.cpp
@@ -72,8 +72,8 @@ IRValue *emitCudaBuiltin(LLVMCodeBuilder &CB, const std::string &Name,
   if (Name == "gridDim.z")
     return CB.createCall("llvm.nvvm.read.ptx.sreg.nctaid.z", RetTy);
   if (Name == "syncThreads") {
-#if LLVM_VERSION_MAJOR >= 22
-    // LLVM 22 replaced the legacy zero-arg barrier0 intrinsic with CTA barrier
+#if LLVM_VERSION_MAJOR >= 21
+    // LLVM 21 replaced the legacy zero-arg barrier0 intrinsic with CTA barrier
     // variants; __syncthreads maps to barrier.cta.sync.aligned.all(0).
     Value *BarrierId = ConstantInt::get(Type::getInt32Ty(CB.getContext()), 0);
     emitVoidIntrinsicCall(CB, Intrinsic::nvvm_barrier_cta_sync_aligned_all,
@@ -223,7 +223,7 @@ LLVMCodeBuilder::LLVMCodeBuilder(std::unique_ptr<LLVMContext> Ctx,
                                  TargetModelType TM)
     : PImpl{std::make_unique<Impl>(std::move(Ctx), std::move(Mod))}, F(nullptr),
       TargetModel(TM) {
-#if LLVM_VERSION_MAJOR >= 22
+#if LLVM_VERSION_MAJOR >= 21
   getModule().setTargetTriple(Triple{getTargetTriple(TM)});
 #else
   getModule().setTargetTriple(getTargetTriple(TM));

--- a/src/runtime/Frontend/LLVMIRJitModule.cpp
+++ b/src/runtime/Frontend/LLVMIRJitModule.cpp
@@ -98,7 +98,7 @@ void LLVMIRJitModule::compile(bool Verify) {
     reportFatalError("LLVMIRJitModule: expected non-null parsed LLVM module");
 
   if (Module->getTargetTriple().empty())
-#if LLVM_VERSION_MAJOR >= 22
+#if LLVM_VERSION_MAJOR >= 21
     Module->setTargetTriple(llvm::Triple(getTargetTriple(TargetModel)));
 #else
     Module->setTargetTriple(getTargetTriple(TargetModel));

--- a/src/runtime/Frontend/MLIRLower.cpp
+++ b/src/runtime/Frontend/MLIRLower.cpp
@@ -107,7 +107,7 @@ static std::string computeTargetDataLayout(llvm::StringRef TargetTriple,
   std::optional<llvm::CodeModel::Model> CodeModel;
 
   std::unique_ptr<llvm::TargetMachine> TM(T->createTargetMachine(
-#if LLVM_VERSION_MAJOR >= 22
+#if LLVM_VERSION_MAJOR >= 21
       llvm::Triple{TargetTriple},
 #else
       TargetTriple,
@@ -203,7 +203,7 @@ static void addGenericToLLVMConversion(mlir::PassManager &PM) {
 static void addHostLoweringPipeline(mlir::PassManager &PM) {
   // HOST path: input is host-side structured IR (func/scf/arith/math/
   // memref); output is host-targeted LLVM dialect before translation.
-#if LLVM_VERSION_MAJOR >= 22
+#if LLVM_VERSION_MAJOR >= 21
   PM.addPass(mlir::createSCFToControlFlowPass());
 #else
   PM.addPass(mlir::createConvertSCFToCFPass());
@@ -226,7 +226,7 @@ static void addHostLoweringPipeline(mlir::PassManager &PM) {
 
 #if PROTEUS_ENABLE_CUDA || PROTEUS_ENABLE_HIP
 static void addCommonGpuLoweringPrelude(mlir::PassManager &PM) {
-#if LLVM_VERSION_MAJOR >= 22
+#if LLVM_VERSION_MAJOR >= 21
   PM.addPass(mlir::createSCFToControlFlowPass());
 #else
   PM.addPass(mlir::createConvertSCFToCFPass());
@@ -518,7 +518,7 @@ static void setFinalLLVMTargetAttrs(llvm::Module &Mod, TargetModelType TM,
                                     llvm::StringRef Features,
                                     llvm::StringRef Prefix) {
   if (!TargetTriple.empty()) {
-#if LLVM_VERSION_MAJOR >= 22
+#if LLVM_VERSION_MAJOR >= 21
     Mod.setTargetTriple(llvm::Triple{TargetTriple});
 #else
     Mod.setTargetTriple(TargetTriple);

--- a/src/runtime/Frontend/MLIRLower.cpp
+++ b/src/runtime/Frontend/MLIRLower.cpp
@@ -236,6 +236,8 @@ static void addCommonGpuLoweringPrelude(mlir::PassManager &PM) {
     Opts.indexBitwidth = mlir::kDeriveIndexBitwidthFromDataLayout;
     PM.addPass(mlir::createConvertControlFlowToLLVMPass(Opts));
   }
+  // Lower internal device helpers before target-specific GPU conversion.
+  PM.addPass(mlir::createConvertFuncToLLVMPass());
   PM.addPass(mlir::createReconcileUnrealizedCastsPass());
 }
 

--- a/src/runtime/JitEngineHost.cpp
+++ b/src/runtime/JitEngineHost.cpp
@@ -377,7 +377,7 @@ JitEngineHost::JitEngineHost() {
   // By dumpSymbolInfo() the debug sections are not populated. Why?
   LLJITPtr = ExitOnErr(
       LLJITBuilder()
-#if LLVM_VERSION_MAJOR >= 22
+#if LLVM_VERSION_MAJOR >= 21
           .setObjectLinkingLayerCreator([&](ExecutionSession &ES) {
             auto GetMemMgr = [](const MemoryBuffer &) {
               return std::make_unique<SectionMemoryManager>();


### PR DESCRIPTION
Fixes #509 
Adds LLVM 21 to Matrix CI, changes necessary LLVM version guards from 22 to 21.