### PR TITLE
Disallow anaconda channel

### DIFF
--- a/.github/workflows/ci-build-test.yml
+++ b/.github/workflows/ci-build-test.yml
@@ -42,7 +42,7 @@ jobs:
       # Build the toolchain env once per LLVM version, then hand it to build jobs.
       - name: Create environment
         run: |
-          conda create -y -n llvm-env -c conda-forge \
+          conda create -y -n llvm-env --override-channels -c conda-forge \
             conda-pack \
             python=3.12 \
             pybind11 \


### PR DESCRIPTION
We were missing one instance of `override-channels` in a CI script, which would allow fallback to Anaconda channels for packages if any are not found in conda-forge. This fixes that