### PR TITLE
ci: pin macOS wheel build to the versioned Homebrew LLVM

### DIFF
--- a/.github/workflows/ci-wheels.yml
+++ b/.github/workflows/ci-wheels.yml
@@ -157,11 +157,6 @@ jobs:
           CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-* cp314-*"
           CIBW_SKIP: "*-musllinux_* cp31?t-*"
           CIBW_MANYLINUX_X86_64_IMAGE: ${{ format('{0}:{1}', env.PROTEUS_MANYLINUX_LLVM_IMAGE_REPO, env.PROTEUS_LLVM_VERSION) }}
-          # Pin the versioned Homebrew keg. Once Homebrew's unversioned llvm
-          # formula moves past PROTEUS_LLVM_VERSION's major, llvm@<major>
-          # becomes its own keg under /opt/homebrew/opt/llvm@<major> and
-          # /opt/homebrew/opt/llvm no longer exists (or points at a newer
-          # LLVM), so never reference the unversioned path here.
           CIBW_BEFORE_ALL_MACOS: brew install llvm@${{ env.PROTEUS_LLVM_MAJOR }}
           CIBW_BEFORE_BUILD_MACOS: python -m pip install delocate
           CIBW_BUILD_VERBOSITY: 1

--- a/.github/workflows/ci-wheels.yml
+++ b/.github/workflows/ci-wheels.yml
@@ -145,6 +145,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
+      - name: Resolve pinned LLVM major
+        shell: bash
+        run: |
+          echo "PROTEUS_LLVM_MAJOR=${PROTEUS_LLVM_VERSION%%.*}" >> "$GITHUB_ENV"
+
       - name: Build host backend wheels
         env:
           CIBW_ARCHS_LINUX: x86_64
@@ -152,17 +157,22 @@ jobs:
           CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-* cp314-*"
           CIBW_SKIP: "*-musllinux_* cp31?t-*"
           CIBW_MANYLINUX_X86_64_IMAGE: ${{ format('{0}:{1}', env.PROTEUS_MANYLINUX_LLVM_IMAGE_REPO, env.PROTEUS_LLVM_VERSION) }}
-          CIBW_BEFORE_ALL_MACOS: brew install llvm@22
+          # Pin the versioned Homebrew keg. Once Homebrew's unversioned llvm
+          # formula moves past PROTEUS_LLVM_VERSION's major, llvm@<major>
+          # becomes its own keg under /opt/homebrew/opt/llvm@<major> and
+          # /opt/homebrew/opt/llvm no longer exists (or points at a newer
+          # LLVM), so never reference the unversioned path here.
+          CIBW_BEFORE_ALL_MACOS: brew install llvm@${{ env.PROTEUS_LLVM_MAJOR }}
           CIBW_BEFORE_BUILD_MACOS: python -m pip install delocate
           CIBW_BUILD_VERBOSITY: 1
           CIBW_ENVIRONMENT_LINUX: >-
             LLVM_INSTALL_DIR=/opt/llvm-${{ env.PROTEUS_LLVM_VERSION }} PATH=/opt/llvm-${{ env.PROTEUS_LLVM_VERSION }}/bin:$PATH
           CIBW_ENVIRONMENT_MACOS: >-
             MACOSX_DEPLOYMENT_TARGET=14.0
-            LLVM_INSTALL_DIR=/opt/homebrew/opt/llvm
-            CC=/opt/homebrew/opt/llvm/bin/clang
-            CXX=/opt/homebrew/opt/llvm/bin/clang++
-            PATH=/opt/homebrew/opt/llvm/bin:$PATH
+            LLVM_INSTALL_DIR=/opt/homebrew/opt/llvm@${{ env.PROTEUS_LLVM_MAJOR }}
+            CC=/opt/homebrew/opt/llvm@${{ env.PROTEUS_LLVM_MAJOR }}/bin/clang
+            CXX=/opt/homebrew/opt/llvm@${{ env.PROTEUS_LLVM_MAJOR }}/bin/clang++
+            PATH=/opt/homebrew/opt/llvm@${{ env.PROTEUS_LLVM_MAJOR }}/bin:$PATH
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: auditwheel repair -w {dest_dir} {wheel}
           CIBW_REPAIR_WHEEL_COMMAND_MACOS: >-
             delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v

--- a/docs/dev/python-wheel.md
+++ b/docs/dev/python-wheel.md
@@ -120,7 +120,7 @@ python3 -m venv /tmp/proteus-wheel-venv
 brew install llvm@22
 
 MACOSX_DEPLOYMENT_TARGET=14.0 \
-LLVM_INSTALL_DIR=/opt/homebrew/opt/llvm \
+LLVM_INSTALL_DIR="$(brew --prefix llvm@22)" \
   /tmp/proteus-wheel-venv/bin/python -m build --wheel \
   --outdir wheelhouse \
   packaging/python/backend-host


### PR DESCRIPTION
Another broken homebrew keg after the default version updates. Should unblock #514 