### PR TITLE
ci: do not error on clang invalid-feature-combination warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ endif()
 message(STATUS "Using LLVM installation: ${LLVM_INSTALL_DIR}")
 
 if (ENABLE_DEVELOPER_COMPILER_FLAGS)
-  add_compile_options(-Wall -Wextra -Werror "-Wno-error=\#warnings" -Wno-error=unknown-cuda-version)
+  add_compile_options(-Wall -Wextra -Werror "-Wno-error=\#warnings" -Wno-error=unknown-cuda-version -Wno-error=invalid-feature-combination)
 endif()
 
 if(ENABLE_COVERAGE)


### PR DESCRIPTION
-march=native on GitHub runners with AVX10 CPUs makes clang emit -Winvalid-feature-combination (+avx10.1-256 promoted to avx10.1-512), which -Werror turns into a spurious build failure.

The is the most common cause of flakiness, so closes #516 .